### PR TITLE
Adding CSS/JS sourcemaps

### DIFF
--- a/src/webpack/env.production.js
+++ b/src/webpack/env.production.js
@@ -15,6 +15,7 @@ const vendorDependencies = Object.keys(dependencies).filter((dependency) => {
 module.exports = function (env) {
   const productionConfig = webpackMerge(baseConfig(), {
     mode: 'production',
+    devtool: 'source-map',
     entry: {
       app: './scripts/index.js',
       vendor: vendorDependencies
@@ -35,10 +36,18 @@ module.exports = function (env) {
             ]
           }
         }),
-        new OptimizeCSSAssetsPlugin(),
+        new OptimizeCSSAssetsPlugin({
+          cssProcessorOptions: {
+            map: {
+              annotation: true,
+              inline: false
+            }
+          }
+        }),
         new UglifyJsPlugin({
           cache: true,
-          parallel: true
+          parallel: true,
+          sourceMap: true
         })
       ],
       splitChunks: {


### PR DESCRIPTION
- Adding sourcemaps for CSS assets.
- Adding sourcemaps for JS assets.

**Notes:**
- All sourcemaps have been setup to be external map files, that include all source code within them.
- CSS line numbers appear confusing at first glance, but it's the line number to the first CSS rule, e.g. index.scss:46 won't point to the start of the selector, it'll point to the elements first inherited rule from that selector.

**Further Reading:**
- https://github.com/NMFR/optimize-css-assets-webpack-plugin/issues/53
- https://github.com/webpack-contrib/mini-css-extract-plugin/issues/141
- https://github.com/webpack-contrib/css-loader#sourcemap
- https://github.com/postcss/postcss-loader#sourcemap
- https://github.com/webpack-contrib/sass-loader#source-maps