### PR TITLE
Removing --ext argument from ESLint CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "npm run webpack:production",
     "eslint-check": "eslint --print-config src/components/app/container/index.js | eslint-config-prettier-check",
-    "lint": "eslint --ext .js server/ src/ test-support/ webpack/",
+    "lint": "eslint server/ src/ test-support/ webpack/",
     "pretest": "npm run lint",
     "start": "node server/index.js",
     "test": "jest",


### PR DESCRIPTION
As above. The argument defaults to `.js` anyway.