### PR TITLE
Using lodash modules to aid in tree shaking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13113,9 +13113,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._basecopy": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "core-js": "3.1.4",
     "express": "4.16.3",
     "immutable": "3.8.2",
-    "lodash": "4.17.10",
+    "lodash": "4.17.15",
     "normalize.css": "8.0.0",
     "prop-types": "15.7.2",
     "react": "16.8.6",

--- a/src/components/loader/index.js
+++ b/src/components/loader/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import isError from 'lodash/isError';
 import classNames from 'classnames';
 import './stylesheets/index.scss';
 
@@ -9,7 +9,7 @@ const namespace = 'app-loader';
 const Loader = function({ children, loadingState }) {
   if (loadingState === true) return children;
 
-  const hasErrored = _.isError(loadingState);
+  const hasErrored = isError(loadingState);
   const headingText = hasErrored ? 'Error while loading' : 'Loading';
   const classes = classNames({
     [namespace]: true,

--- a/src/reducers/selectors/data-loaded.js
+++ b/src/reducers/selectors/data-loaded.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import isUndefined from 'lodash/isUndefined';
 import { createSelector } from 'reselect';
 import charactersSelector from '../characters/selectors/characters';
 import charactersRequestSelector from '../characters/selectors/characters-request';
@@ -19,7 +19,7 @@ export const transform = function(
     return false;
   }
 
-  return _.isUndefined(characters) || _.isUndefined(powersAndEnhancements)
+  return isUndefined(characters) || isUndefined(powersAndEnhancements)
     ? false
     : true;
 };

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -12,7 +12,6 @@ module.exports = function() {
       publicPath: '/'
     },
     module: {
-      noParse: [/node_modules\/immutable/, /node_modules\/underscore/],
       rules: [
         {
           test: /\.jsx?$/,


### PR DESCRIPTION
Before this PR, the entirety of `lodash` was being included rather than only just the modules from it that are used.

- Removes the `noParse` entry from webpack; `underscore` isn't even in the build, and the time savings we got from not parsing `immutable` are negligible.
- Bumps `lodash` to the latest version.
- Updating all usage of `lodash` to import a specific module, resulting in a **68kb** reduction in file size.

| Before (Vendor = 346kb) | After (Vendor = 278kb) |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/167421/62579494-d71db200-b89b-11e9-9fb0-4067f27abee2.png) | ![after](https://user-images.githubusercontent.com/167421/62579479-cb31f000-b89b-11e9-9648-bc6dd7521849.png) |