### PR TITLE
Ensuring babel-preset-env targets node in the test environment

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -21,7 +21,12 @@
     "test": {
       "presets": [
         [
-          "@babel/preset-env"
+          "@babel/preset-env",
+          {
+            "targets": {
+              "node": "current"
+            }
+          }
         ],
         "@babel/preset-react"
       ]


### PR DESCRIPTION
As above. This PR ensures that any polyfilling required for the test environment takes into considering the current version of node in use.