### PR TITLE
Simplifying hot module reloading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16163,9 +16163,9 @@
       }
     },
     "react-hot-loader": {
-      "version": "4.12.6",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.6.tgz",
-      "integrity": "sha512-tRXWgF5MhQSEXX3EHIplCOWCzSg+ye7ddHeQLt7Z+CaZMeEfeCL2/uSGITIzWXOQYhefnLX8IZtr2cff4xIrww==",
+      "version": "4.12.11",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.11.tgz",
+      "integrity": "sha512-ySsg1hPwr/5dkZCJVp1nZRbwbpbEQ+3e2+bn/D681Wvr9+o+5bLKkTGq0TXskj8HgCS3ScysXddOng9Cg+JKzw==",
       "requires": {
         "fast-levenshtein": "^2.0.6",
         "global": "^4.3.0",
@@ -16173,7 +16173,7 @@
         "loader-utils": "^1.1.0",
         "prop-types": "^15.6.1",
         "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.0.2",
+        "shallowequal": "^1.1.0",
         "source-map": "^0.7.3"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react": "16.8.6",
     "react-code-splitting": "1.2.1",
     "react-dom": "16.8.6",
-    "react-hot-loader": "4.12.6",
+    "react-hot-loader": "4.12.11",
     "react-immutable-proptypes": "2.1.0",
     "react-redux": "7.1.0",
     "react-router-dom": "5.0.1",

--- a/src/components/app/container/index.js
+++ b/src/components/app/container/index.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { withRouter } from 'react-router';
+import { hot } from 'react-hot-loader/root';
 import { fetchCharacters } from '../../../reducers/characters';
 import { fetchPowers } from '../../../reducers/powers';
 import dataLoadedSelector from '../../../reducers/selectors/data-loaded';
@@ -19,9 +20,11 @@ const mapDispatchToProps = function(dispatch) {
   };
 };
 
-export default withRouter(
+const connectedComponent = withRouter(
   connect(
     mapStateToProps,
     mapDispatchToProps
   )(Component)
 );
+
+export default hot(connectedComponent);

--- a/src/index.js
+++ b/src/index.js
@@ -1,32 +1,17 @@
-/* global module */
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { AppContainer } from 'react-hot-loader';
 import store from './store';
 import App from './components/app/container';
 
-const render = (Component) => {
-  ReactDOM.render(
-    <Provider store={store}>
-      <Router>
-        <AppContainer>
-          <React.StrictMode>
-            <Component />
-          </React.StrictMode>
-        </AppContainer>
-      </Router>
-    </Provider>,
-    document.querySelector('#application')
-  );
-};
-
-render(App);
-
-if (module.hot) {
-  module.hot.accept('./components/app/container', () => {
-    render(App);
-  });
-}
+ReactDOM.render(
+  <Provider store={store}>
+    <Router>
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>
+    </Router>
+  </Provider>,
+  document.querySelector('#application')
+);

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -6,7 +6,9 @@ const paths = require('./paths');
 module.exports = function() {
   return {
     mode: 'none',
-    entry: null,
+    entry: {
+      app: './src/index.js'
+    },
     output: {
       path: paths.dist,
       publicPath: '/'

--- a/webpack/env.development.js
+++ b/webpack/env.development.js
@@ -1,4 +1,3 @@
-const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -8,12 +7,6 @@ const baseConfig = require('./base');
 module.exports = function() {
   return webpackMerge(baseConfig(), {
     mode: 'development',
-    entry: [
-      'react-hot-loader/patch',
-      `webpack-dev-server/client?http://localhost:${Number(process.env.PORT)}`,
-      'webpack/hot/only-dev-server',
-      './src/index.js'
-    ],
     output: {
       chunkFilename: 'js/[name].js',
       filename: 'js/[name].js'
@@ -43,7 +36,6 @@ module.exports = function() {
       ]
     },
     plugins: [
-      new webpack.HotModuleReplacementPlugin(),
       new CopyWebpackPlugin(
         [
           {

--- a/webpack/env.production.js
+++ b/webpack/env.production.js
@@ -11,9 +11,6 @@ module.exports = function(env) {
   const productionConfig = webpackMerge(baseConfig(), {
     mode: 'production',
     devtool: 'source-map',
-    entry: {
-      app: './src/index.js'
-    },
     optimization: {
       minimizer: [
         new ImageminPlugin({


### PR DESCRIPTION
- Updates `react-hot-loader` to latest version.
- Removing the hot module webpack implementation and moving `entry` configuration to base.
- Removing the old `module.hot.accept` in favour of the simpler `hot` HOC.