### PR TITLE
Using React.lazy and React.Suspense instead of third-party library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16896,16 +16896,6 @@
         "prop-types": "^15.6.2"
       }
     },
-    "react-code-splitting": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/react-code-splitting/-/react-code-splitting-1.2.1.tgz",
-      "integrity": "sha512-z8oGYRX17FiuqjD6T9AAJTVIxf/upfbRvuDdoQHqc7JfGfm0jWR6/vILiV73CjQoyHGfbGiVqGGy93uuO+rnyg==",
-      "requires": {
-        "prop-types": "^15.5.8",
-        "react": "^16.0.0",
-        "react-dom": "^16.0.0"
-      }
-    },
     "react-dom": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "normalize.css": "8.0.1",
     "prop-types": "15.7.2",
     "react": "16.9.0",
-    "react-code-splitting": "1.2.1",
     "react-dom": "16.9.0",
     "react-hot-loader": "4.12.11",
     "react-immutable-proptypes": "2.1.0",

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -1,7 +1,6 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import PropTypes from 'prop-types';
 import { Switch, Route } from 'react-router-dom';
-import Async from 'react-code-splitting';
 import 'normalize.css';
 import './stylesheets/index.scss';
 import Loader from '../loader';
@@ -9,24 +8,18 @@ import gameLogo from '../../../images/game-logo.png';
 
 const namespace = 'app';
 
-const CharacterSelection = (props) => (
-  <Async
-    componentProps={props}
-    load={import(
-      /* webpackChunkName: "character-selection" */
-      '../character-selection/container'
-    )}
-  />
+const CharacterSelection = lazy(() =>
+  import(
+    /* webpackChunkName: "character-selection" */
+    '../character-selection/container'
+  )
 );
 
-const PowerSelection = (props) => (
-  <Async
-    componentProps={props}
-    load={import(
-      /* webpackChunkName: "power-selection" */
-      '../power-selection/container'
-    )}
-  />
+const PowerSelection = lazy(() =>
+  import(
+    /* webpackChunkName: "power-selection" */
+    '../power-selection/container'
+  )
 );
 
 class App extends React.Component {
@@ -53,10 +46,12 @@ class App extends React.Component {
         </header>
         <div className={`${namespace}__content`}>
           <Loader loadingState={this.props.dataLoaded}>
-            <Switch>
-              <Route exact path="/" component={CharacterSelection} />
-              <Route path="/:characterId/powers" component={PowerSelection} />
-            </Switch>
+            <Suspense fallback={<Loader loadingState={false} />}>
+              <Switch>
+                <Route exact path="/" component={CharacterSelection} />
+                <Route path="/:characterId/powers" component={PowerSelection} />
+              </Switch>
+            </Suspense>
           </Loader>
         </div>
       </div>


### PR DESCRIPTION
This PR removes `react-code-splitting` in favour of using built-in React functionality via `React.lazy` and `React.Suspense`. This removal of a third party library gives us around ~2kb back.

`React.lazy` takes a dynamic import and wraps a React component around it. `React.Suspense` will render fallback content instead of it's children, should a lazily loaded child component be currently loading and in flight.