### PR TITLE
Using hot-loader version of react-dom in development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1581,6 +1581,18 @@
         }
       }
     },
+    "@hot-loader/react-dom": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-16.9.0.tgz",
+      "integrity": "sha512-MsOdCBB7c5YNyB4iDDct+tS7AihvYyfwZVV+z/QnbTjPgxH98kqIDXO92nU7tLXp0OtYFErHZfcWjtszP/572w==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.15.0"
+      }
+    },
     "@jest/console": {
       "version": "24.7.1",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@babel/plugin-transform-runtime": "7.5.5",
     "@babel/preset-env": "7.5.5",
     "@babel/preset-react": "7.0.0",
+    "@hot-loader/react-dom": "16.9.0",
     "autoprefixer": "9.6.1",
     "babel-eslint": "10.0.2",
     "babel-jest": "24.8.0",

--- a/webpack/env.development.js
+++ b/webpack/env.development.js
@@ -25,6 +25,11 @@ module.exports = function() {
         }
       )
     ],
+    resolve: {
+      alias: {
+        'react-dom': '@hot-loader/react-dom'
+      }
+    },
     devServer: {
       compress: true,
       contentBase: paths.dist,


### PR DESCRIPTION
This PR overloads the react version of `react-dom` with a hot loader version of the package. This allows us to use modern react techniques such as hooks.