### PR TITLE
Implementing react-axe into development builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3917,6 +3917,12 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "axe-core": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.3.1.tgz",
+      "integrity": "sha512-gw1T0JptHPF4AdLLqE8yQq3Z7YvsYkpFmFWd84r6hnq/QoKRr8icYHFumhE7wYl5TVIHgVlchMyJsAYh0CfwCQ==",
+      "dev": true
+    },
     "axios": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
@@ -16908,6 +16914,16 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-axe": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-axe/-/react-axe-3.2.0.tgz",
+      "integrity": "sha512-2KlO2wZq58+GSFP4oWA2ZjU1ggbXdDLJc7tMUXUXkE4NVQ3FftdYtb7qNR+x1nTLeuVYiH4nH4hzIz9vQZ/Chw==",
+      "dev": true,
+      "requires": {
+        "axe-core": "^3.0.0",
+        "requestidlecallback": "^0.3.0"
+      }
+    },
     "react-dom": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
@@ -17843,6 +17859,12 @@
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
       }
+    },
+    "requestidlecallback": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+      "integrity": "sha1-b7dOBzP5DfP6pIOPn2oqX5t0KsU=",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "optimize-css-assets-webpack-plugin": "5.0.3",
     "postcss-loader": "3.0.0",
     "prettier": "1.18.2",
+    "react-axe": "3.2.0",
     "react-test-renderer": "16.9.0",
     "redux-mock-store": "1.5.3",
     "sass-loader": "7.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+/* global process */
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
@@ -5,13 +7,24 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import store from './store';
 import App from './components/app/container';
 
-ReactDOM.render(
-  <Provider store={store}>
-    <Router>
-      <React.StrictMode>
-        <App />
-      </React.StrictMode>
-    </Router>
-  </Provider>,
-  document.querySelector('#application')
-);
+const renderApplication = () => {
+  ReactDOM.render(
+    <Provider store={store}>
+      <Router>
+        <React.StrictMode>
+          <App />
+        </React.StrictMode>
+      </Router>
+    </Provider>,
+    document.querySelector('#application')
+  );
+};
+
+if (process.env.NODE_ENV !== 'production') {
+  import('react-axe').then(({ default: axe }) => {
+    axe(React, ReactDOM, 1000);
+    renderApplication();
+  });
+} else {
+  renderApplication();
+}


### PR DESCRIPTION
This PR implements `react-axe` to compliment the already implemented `eslint-plugin-jsx-a11y` module.

This PR shouldn't be merged until `react-axe` cuts a version that stops relying on it's internal using of `React.findDOMNode` as it's conflicting with `React.StrictMode`.

An issue has been logged on `react-axe`:
https://github.com/dequelabs/react-axe/issues/105