### PR TITLE
Fixing server

### DIFF
--- a/server/index.mjs
+++ b/server/index.mjs
@@ -1,7 +1,7 @@
 import path from 'path';
 import express from 'express';
 import compression from 'compression';
-import paths from '../support/paths';
+import paths from '../support/paths.js';
 import characters from './characters.json';
 import powers from './powers.json';
 


### PR DESCRIPTION
The `server/index.mjs` file needs relative JS files to include an extension, so it can differentiate between a node module and a source file.