### PR TITLE
Testing app container and component

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,6 +46,7 @@
   "overrides": [
     {
       "files": [
+        "**/__mocks__/*.js",
         "**/*.spec.{js,mjs}"
       ],
       "env": {

--- a/__mocks__/react-redux.js
+++ b/__mocks__/react-redux.js
@@ -1,0 +1,17 @@
+const mockDispatch = jest.fn((action) => action);
+
+afterEach(() => {
+  mockDispatch.mockClear();
+});
+
+export const connect = (mapStateToProps, mapDispatchToProps) => (
+  Component
+) => ({
+  mapStateToProps,
+  mapDispatchToProps: (dispatch = mockDispatch, ownProps) =>
+    mapDispatchToProps(dispatch, ownProps),
+  Component,
+  mockDispatch
+});
+
+export const Provider = ({ children }) => children;

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     '^Api(.*)$': '<rootDir>/src/api$1',
     '^Components(.*)$': '<rootDir>/src/components$1',
     '^Constants(.*)$': '<rootDir>/src/constants$1',
+    '^Images(.*)$': '<rootDir>/images$1',
     '^Reducers(.*)$': '<rootDir>/src/reducers$1',
     '^Src(.*)$': '<rootDir>/src$1',
     '\\.(css|scss|sass)$': '<rootDir>/support/tests/style-mock.js'

--- a/src/components/app/container/tests/index.spec.js
+++ b/src/components/app/container/tests/index.spec.js
@@ -1,0 +1,57 @@
+import Container from '../';
+
+jest.mock('react-hot-loader/root', () => ({
+  hot: (component) => component
+}));
+
+jest.mock('Reducers/characters', () => ({
+  getCharacters: () => 'MockGetCharactersAction'
+}));
+
+jest.mock('Reducers/powers', () => ({
+  getPowers: () => 'MockGetPowersAction'
+}));
+
+jest.mock('Src/selectors', () => ({
+  hasInitialDataFailedSelector: jest
+    .fn()
+    .mockReturnValue('hasInitialDataFailedSelector'),
+  isInitialDataLoadingSelector: jest
+    .fn()
+    .mockReturnValue('isInitialDataLoadingSelector')
+}));
+
+jest.mock('../../', () => 'MockComponent');
+
+describe('App container', () => {
+  describe('#mapStateToProps', () => {
+    it('returns expected key/value pairings', () => {
+      expect(Container.mapStateToProps()).toEqual({
+        showError: 'hasInitialDataFailedSelector',
+        showLoader: 'isInitialDataLoadingSelector'
+      });
+    });
+  });
+
+  describe('#mapDispatchToProps', () => {
+    describe('#onComponentDidMount', () => {
+      beforeEach(() => {
+        Container.mapDispatchToProps().onComponentDidMount();
+      });
+
+      it('firstly fires action for getting characters', () => {
+        expect(Container.mockDispatch).toHaveBeenNthCalledWith(
+          1,
+          'MockGetCharactersAction'
+        );
+      });
+
+      it('secondly fires action for getting powers', () => {
+        expect(Container.mockDispatch).toHaveBeenNthCalledWith(
+          2,
+          'MockGetPowersAction'
+        );
+      });
+    });
+  });
+});

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -1,34 +1,16 @@
-import React, { Suspense, lazy, useEffect } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Switch, Route } from 'react-router-dom';
 import 'normalize.css';
 import './stylesheets/index.scss';
+import CharacterSelection from 'Components/character-selection/lazy';
 import Loader from 'Components/loader';
+import PageNotFound from 'Components/page-not-found/lazy';
+import PowerSelection from 'Components/power-selection/lazy';
 import logo660 from 'Images/logo/660x90.png';
 import logo1320 from 'Images/logo/1320x180.png';
 
 const namespace = 'app';
-
-const CharacterSelection = lazy(() =>
-  import(
-    /* webpackChunkName: "character-selection" */
-    '../character-selection/container'
-  )
-);
-
-const PowerSelection = lazy(() =>
-  import(
-    /* webpackChunkName: "power-selection" */
-    '../power-selection/container'
-  )
-);
-
-const PageNotFound = lazy(() =>
-  import(
-    /* webpackChunkName: "page-not-found" */
-    '../page-not-found'
-  )
-);
 
 const App = ({ onComponentDidMount, showError, showLoader }) => {
   useEffect(() => {

--- a/src/components/app/tests/__snapshots__/index.spec.js.snap
+++ b/src/components/app/tests/__snapshots__/index.spec.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`App component when rendered renders a header area and top-level routes 1`] = `
+<div
+  className="app"
+>
+  <header
+    className="app__header"
+  >
+    <h1
+      className="app__title"
+    >
+      Power Calculator
+    </h1>
+    <img
+      alt="Dishonored 2 logo"
+      className="app__logo"
+      sizes="100vw"
+      srcSet="660x90.png 660w, 1320x180.png 1320w"
+    />
+  </header>
+  <div
+    className="app__content"
+  >
+    <MockLoader
+      showError={false}
+      showLoader={true}
+    >
+      <MockSwitch>
+        <MockRoute
+          component="MockCharacterSelection"
+          exact={true}
+          path="/"
+        />
+        <MockRoute
+          component="MockPowerSelection"
+          path="/:characterId/powers"
+        />
+        <MockRoute
+          component="MockPageNotFound"
+        />
+      </MockSwitch>
+    </MockLoader>
+  </div>
+</div>
+`;

--- a/src/components/app/tests/index.spec.js
+++ b/src/components/app/tests/index.spec.js
@@ -1,0 +1,60 @@
+import noop from 'lodash/noop';
+import React from 'react';
+import renderer from 'react-test-renderer';
+import App from '../';
+
+jest.mock('react-router-dom', () => ({
+  Switch: 'MockSwitch',
+  Route: 'MockRoute'
+}));
+
+jest.mock(
+  'Components/character-selection/lazy',
+  () => 'MockCharacterSelection'
+);
+
+jest.mock('Components/loader', () => 'MockLoader');
+
+jest.mock('Components/page-not-found/lazy', () => 'MockPageNotFound');
+
+jest.mock('Components/power-selection/lazy', () => 'MockPowerSelection');
+
+describe('App component', () => {
+  let testContext;
+
+  const renderComponent = (props) => (
+    <App {...testContext.defaultProps} {...props} />
+  );
+
+  beforeEach(() => {
+    testContext = {};
+
+    testContext.defaultProps = {
+      onComponentDidMount: noop,
+      showError: false,
+      showLoader: true
+    };
+  });
+
+  describe('when rendered', () => {
+    beforeEach(() => {
+      testContext.onComponentDidMountMock = jest.fn();
+
+      renderer.act(() => {
+        testContext.component = renderer.create(
+          renderComponent({
+            onComponentDidMount: testContext.onComponentDidMountMock
+          })
+        );
+      });
+    });
+
+    it('renders a header area and top-level routes', () => {
+      expect(testContext.component).toMatchSnapshot();
+    });
+
+    it('triggers prop callback on mounting', () => {
+      expect(testContext.onComponentDidMountMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/character-selection/lazy.js
+++ b/src/components/character-selection/lazy.js
@@ -1,0 +1,8 @@
+import { lazy } from 'react';
+
+export default lazy(() =>
+  import(
+    /* webpackChunkName: "character-selection" */
+    './container'
+  )
+);

--- a/src/components/page-not-found/lazy.js
+++ b/src/components/page-not-found/lazy.js
@@ -1,0 +1,8 @@
+import { lazy } from 'react';
+
+export default lazy(() =>
+  import(
+    /* webpackChunkName: "page-not-found" */
+    './'
+  )
+);

--- a/src/components/power-selection/lazy.js
+++ b/src/components/power-selection/lazy.js
@@ -1,0 +1,8 @@
+import { lazy } from 'react';
+
+export default lazy(() =>
+  import(
+    /* webpackChunkName: "power-selection" */
+    './container'
+  )
+);

--- a/webpack/env.production.js
+++ b/webpack/env.production.js
@@ -48,7 +48,7 @@ module.exports = function(env = {}) {
         cacheGroups: {
           default: false,
           vendor: {
-            chunks: 'initial',
+            chunks: 'all',
             enforce: true,
             name: 'vendor',
             test: /[\\/]node_modules[\\/](?!normalize)/


### PR DESCRIPTION
- Adding images path to jest configuration so modules that import images via this path don't error on the test suite.
- Moving the lazy loading of components into their own modules so the `App` component is easier to test.
- Shared node modules on async chunks were not smartly pushing their shared node modules into the vendor bundle. This PR updates the chunk targeting of the vendor bundle to target all bundles, which results in all node modules being stored within vendor.
- Adding mock module for `react-redux` then adding tests for container / component of `App`.