### PR TITLE
Adding character slugs

### DIFF
--- a/server/characters.json
+++ b/server/characters.json
@@ -4,6 +4,7 @@
       "id": "de2351c7-f1c3-409d-8973-414d5c37364c",
       "type": "characters",
       "attributes": {
+        "slug": "corvo",
         "name": "Corvo",
         "description": "Legendary Royal Protector to the Empress, and figure of infamy from the time of the Rat Plague."
       }
@@ -12,6 +13,7 @@
       "id": "eb903f97-3dcb-44a5-ba95-d4b277d8c55a",
       "type": "characters",
       "attributes": {
+        "slug": "emily",
         "name": "Emily",
         "description": "Ruler of the Empire of the Isles, trained in stealth and combat by her father, Corvo Attano."
       }

--- a/src/api/sample-responses/get-characters-success.json
+++ b/src/api/sample-responses/get-characters-success.json
@@ -4,6 +4,7 @@
       "id": "fake-uuid-01",
       "type": "characters",
       "attributes": {
+        "slug": "fake-slug-01",
         "name": "fake-name-01",
         "description": "fake-description-01"
       }
@@ -12,6 +13,7 @@
       "id": "fake-uuid-02",
       "type": "characters",
       "attributes": {
+        "slug": "fake-slug-02",
         "name": "fake-name-02",
         "description": "fake-description-02"
       }

--- a/src/components/app/container/index.js
+++ b/src/components/app/container/index.js
@@ -3,14 +3,14 @@ import { hot } from 'react-hot-loader/root';
 import { getCharacters } from 'Reducers/characters';
 import { getPowers } from 'Reducers/powers';
 import {
-  isInitialDataLoadingSelector,
+  isInitialDataIncompleteSelector,
   hasInitialDataFailedSelector
 } from 'Src/selectors';
 import Component from '../';
 
 const mapStateToProps = (state) => ({
   showError: hasInitialDataFailedSelector(state),
-  showLoader: isInitialDataLoadingSelector(state)
+  showLoader: isInitialDataIncompleteSelector(state)
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/components/app/container/tests/index.spec.js
+++ b/src/components/app/container/tests/index.spec.js
@@ -16,9 +16,9 @@ jest.mock('Src/selectors', () => ({
   hasInitialDataFailedSelector: jest
     .fn()
     .mockReturnValue('hasInitialDataFailedSelector'),
-  isInitialDataLoadingSelector: jest
+  isInitialDataIncompleteSelector: jest
     .fn()
-    .mockReturnValue('isInitialDataLoadingSelector')
+    .mockReturnValue('isInitialDataIncompleteSelector')
 }));
 
 jest.mock('../../', () => 'MockComponent');
@@ -28,7 +28,7 @@ describe('App container', () => {
     it('returns expected key/value pairings', () => {
       expect(Container.mapStateToProps()).toEqual({
         showError: 'hasInitialDataFailedSelector',
-        showLoader: 'isInitialDataLoadingSelector'
+        showLoader: 'isInitialDataIncompleteSelector'
       });
     });
   });

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -32,9 +32,15 @@ const App = ({ onComponentDidMount, showError, showLoader }) => {
         <Loader showError={showError} showLoader={showLoader}>
           <Suspense fallback={<Loader showLoader={true} />}>
             <Switch>
-              <Route exact path="/" component={CharacterSelection} />
-              <Route path="/:characterId/powers" component={PowerSelection} />
-              <Route component={PageNotFound} />
+              <Route exact path="/">
+                <CharacterSelection />
+              </Route>
+              <Route path="/:characterSlug/powers">
+                <PowerSelection />
+              </Route>
+              <Route>
+                <PageNotFound />
+              </Route>
             </Switch>
           </Suspense>
         </Loader>

--- a/src/components/app/tests/__snapshots__/index.spec.js.snap
+++ b/src/components/app/tests/__snapshots__/index.spec.js.snap
@@ -28,17 +28,19 @@ exports[`App component when rendered renders a header area and top-level routes 
     >
       <MockSwitch>
         <MockRoute
-          component="MockCharacterSelection"
           exact={true}
           path="/"
-        />
+        >
+          <MockCharacterSelection />
+        </MockRoute>
         <MockRoute
-          component="MockPowerSelection"
-          path="/:characterId/powers"
-        />
-        <MockRoute
-          component="MockPageNotFound"
-        />
+          path="/:characterSlug/powers"
+        >
+          <MockPowerSelection />
+        </MockRoute>
+        <MockRoute>
+          <MockPageNotFound />
+        </MockRoute>
       </MockSwitch>
     </MockLoader>
   </div>

--- a/src/components/character-selection/container/index.js
+++ b/src/components/character-selection/container/index.js
@@ -6,9 +6,4 @@ const mapStateToProps = (state) => ({
   characters: charactersDataSelector(state)
 });
 
-const mapDispatchToProps = () => ({});
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Component);
+export default connect(mapStateToProps)(Component);

--- a/src/components/character-selection/index.js
+++ b/src/components/character-selection/index.js
@@ -3,17 +3,15 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import { Link } from 'react-router-dom';
 
 const CharacterSelection = (props) => {
-  const characterElements = props.characters.valueSeq().map((character) => {
-    const characterURL = `/${character.get('id')}/powers`;
-
-    return (
-      <div className="character__container" key={character.get('id')}>
-        <h2 className="character__name">{character.get('name')}</h2>
-        <p className="character__description">{character.get('description')}</p>
-        <Link to={characterURL}>Choose {character.get('name')}</Link>
-      </div>
-    );
-  });
+  const characterElements = props.characters.valueSeq().map((character) => (
+    <div className="character__container" key={character.get('id')}>
+      <h2 className="character__name">{character.get('name')}</h2>
+      <p className="character__description">{character.get('description')}</p>
+      <Link to={`/${character.get('slug')}/powers`}>
+        Choose {character.get('name')}
+      </Link>
+    </div>
+  ));
 
   return (
     <section className="characterSelection__container">

--- a/src/components/character-selection/tests/__snapshots__/index.spec.js.snap
+++ b/src/components/character-selection/tests/__snapshots__/index.spec.js.snap
@@ -21,7 +21,7 @@ exports[`CharacterSelection component when rendered renders a heading with sub-a
       Task Force 29 operative.
     </p>
     <MockLink
-      to="/dummy-id/powers"
+      to="/dummy-slug/powers"
     >
       Choose 
       Adam Jensen
@@ -41,7 +41,7 @@ exports[`CharacterSelection component when rendered renders a heading with sub-a
       The pathfinder.
     </p>
     <MockLink
-      to="/fake-id/powers"
+      to="/fake-slug/powers"
     >
       Choose 
       Scott Ryder

--- a/src/components/character-selection/tests/index.spec.js
+++ b/src/components/character-selection/tests/index.spec.js
@@ -19,11 +19,13 @@ describe('CharacterSelection component', () => {
       characters: Immutable.fromJS({
         dummyUuid: {
           id: 'dummy-id',
+          slug: 'dummy-slug',
           name: 'Adam Jensen',
           description: 'Task Force 29 operative.'
         },
         fakeUuid: {
           id: 'fake-id',
+          slug: 'fake-slug',
           name: 'Scott Ryder',
           description: 'The pathfinder.'
         }

--- a/src/reducers/characters/index.js
+++ b/src/reducers/characters/index.js
@@ -37,6 +37,7 @@ export const getCharacters = () => {
           character.get('id'),
           Immutable.Map({
             id: character.get('id'),
+            slug: character.getIn(['attributes', 'slug']),
             name: character.getIn(['attributes', 'name']),
             description: character.getIn(['attributes', 'description'])
           })

--- a/src/reducers/characters/tests/index.spec.js
+++ b/src/reducers/characters/tests/index.spec.js
@@ -130,11 +130,13 @@ describe('Characters action creators', () => {
               characters: Immutable.fromJS({
                 'fake-uuid-01': {
                   id: 'fake-uuid-01',
+                  slug: 'fake-slug-01',
                   name: 'fake-name-01',
                   description: 'fake-description-01'
                 },
                 'fake-uuid-02': {
                   id: 'fake-uuid-02',
+                  slug: 'fake-slug-02',
                   name: 'fake-name-02',
                   description: 'fake-description-02'
                 }

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -4,10 +4,10 @@ import requestStatuses from 'Constants/request-statuses';
 import * as charactersReducerSelectors from 'Reducers/characters/selectors';
 import * as powersReducerSelectors from 'Reducers/powers/selectors';
 
-const isRequestStatusPending = (requestStatus) =>
-  requestStatus === requestStatuses.pending;
+const isRequestIncomplete = (requestStatus) =>
+  [requestStatuses.idle, requestStatuses.pending].includes(requestStatus);
 
-const hasRequestStatusFailed = (requestStatus) =>
+const hasRequestFailed = (requestStatus) =>
   requestStatus === requestStatuses.failure;
 
 const charactersSelector = (state) => state.get('characters', Immutable.Map());
@@ -29,14 +29,14 @@ const powersRequestStatusSelector = createSelector(
   powersReducerSelectors.requestStatusSelector
 );
 
-export const isInitialDataLoadingSelector = createSelector(
+export const isInitialDataIncompleteSelector = createSelector(
   charactersRequestStatusSelector,
   powersRequestStatusSelector,
-  (...statuses) => statuses.some(isRequestStatusPending)
+  (...statuses) => statuses.some(isRequestIncomplete)
 );
 
 export const hasInitialDataFailedSelector = createSelector(
   charactersRequestStatusSelector,
   powersRequestStatusSelector,
-  (...statuses) => statuses.some(hasRequestStatusFailed)
+  (...statuses) => statuses.some(hasRequestFailed)
 );

--- a/src/tests/selectors.spec.js
+++ b/src/tests/selectors.spec.js
@@ -25,7 +25,23 @@ describe('Selectors', () => {
     });
   });
 
-  describe('#isInitialDataLoadingSelector', () => {
+  describe('#isInitialDataIncompleteSelector', () => {
+    describe('when characters request is idle', () => {
+      beforeEach(() => {
+        testContext.state = Immutable.fromJS({
+          characters: {
+            requestStatus: requestStatuses.idle
+          }
+        });
+      });
+
+      it('returns true', () => {
+        expect(
+          selectors.isInitialDataIncompleteSelector(testContext.state)
+        ).toEqual(true);
+      });
+    });
+
     describe('when characters request is pending', () => {
       beforeEach(() => {
         testContext.state = Immutable.fromJS({
@@ -37,7 +53,23 @@ describe('Selectors', () => {
 
       it('returns true', () => {
         expect(
-          selectors.isInitialDataLoadingSelector(testContext.state)
+          selectors.isInitialDataIncompleteSelector(testContext.state)
+        ).toEqual(true);
+      });
+    });
+
+    describe('when powers request is idle', () => {
+      beforeEach(() => {
+        testContext.state = Immutable.fromJS({
+          powers: {
+            requestStatus: requestStatuses.idle
+          }
+        });
+      });
+
+      it('returns true', () => {
+        expect(
+          selectors.isInitialDataIncompleteSelector(testContext.state)
         ).toEqual(true);
       });
     });
@@ -53,19 +85,19 @@ describe('Selectors', () => {
 
       it('returns true', () => {
         expect(
-          selectors.isInitialDataLoadingSelector(testContext.state)
+          selectors.isInitialDataIncompleteSelector(testContext.state)
         ).toEqual(true);
       });
     });
 
-    describe('when neither request is pending', () => {
+    describe('when neither request is pending nor idle', () => {
       beforeEach(() => {
         testContext.state = Immutable.Map();
       });
 
       it('returns false', () => {
         expect(
-          selectors.isInitialDataLoadingSelector(testContext.state)
+          selectors.isInitialDataIncompleteSelector(testContext.state)
         ).toEqual(false);
       });
     });


### PR DESCRIPTION
- Fixing oversight where initial render of `App` rendered routes and their components, whenever loader should've been shown to stop this, until requests had completed. Selectors weren't taking the `idle` state of requests into consideration.

- Updating characters response with `slug` attribute and ensuring it's saved into the flux store.

- Updating `CharacterSelection` component to build links using `slug` rather than `id`.

- Tidying `CharacterSelection` container to not pass a superfluous, optional, `mapDispatchToProps` method to the `connect` method.

- Updating route composition to follow latest advice on the libraries "Examples" of their website. Components have been moved to be children of the routes, to keep in theme with reacts concept of composition. This seems better than having `Route` components with a ton of props but no children.