### PR TITLE
Routing validation

### DIFF
--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -6,7 +6,7 @@ import './stylesheets/index.scss';
 import CharacterSelection from 'Components/character-selection/lazy';
 import Loader from 'Components/loader';
 import PageNotFound from 'Components/page-not-found/lazy';
-import PowerSelection from 'Components/power-selection/lazy';
+import PowerSelectionRouteValidation from 'Components/power-selection/lazy';
 import logo660 from 'Images/logo/660x90.png';
 import logo1320 from 'Images/logo/1320x180.png';
 
@@ -36,7 +36,7 @@ const App = ({ onComponentDidMount, showError, showLoader }) => {
                 <CharacterSelection />
               </Route>
               <Route path="/:characterSlug/powers">
-                <PowerSelection />
+                <PowerSelectionRouteValidation />
               </Route>
               <Route>
                 <PageNotFound />

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -15,7 +15,7 @@ const namespace = 'app';
 const App = ({ onComponentDidMount, showError, showLoader }) => {
   useEffect(() => {
     onComponentDidMount();
-  }, []);
+  }, [onComponentDidMount]);
 
   return (
     <div className={namespace}>

--- a/src/components/app/tests/__snapshots__/index.spec.js.snap
+++ b/src/components/app/tests/__snapshots__/index.spec.js.snap
@@ -36,7 +36,7 @@ exports[`App component when rendered renders a header area and top-level routes 
         <MockRoute
           path="/:characterSlug/powers"
         >
-          <MockPowerSelection />
+          <MockPowerSelectionRouteValidation />
         </MockRoute>
         <MockRoute>
           <MockPageNotFound />

--- a/src/components/app/tests/index.spec.js
+++ b/src/components/app/tests/index.spec.js
@@ -17,7 +17,10 @@ jest.mock('Components/loader', () => 'MockLoader');
 
 jest.mock('Components/page-not-found/lazy', () => 'MockPageNotFound');
 
-jest.mock('Components/power-selection/lazy', () => 'MockPowerSelection');
+jest.mock(
+  'Components/power-selection/lazy',
+  () => 'MockPowerSelectionRouteValidation'
+);
 
 describe('App component', () => {
   let testContext;

--- a/src/components/power-selection/container/route-validation.js
+++ b/src/components/power-selection/container/route-validation.js
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { characterBySlugSelector } from 'Src/selectors';
+import Component from '../route-validation';
+
+export const mapStateToProps = (state, ownProps) => {
+  const characterSlug = ownProps.match.params.characterSlug;
+
+  return {
+    character: characterBySlugSelector(state, characterSlug)
+  };
+};
+
+export default withRouter(connect(mapStateToProps)(Component));

--- a/src/components/power-selection/container/tests/route-validation.spec.js
+++ b/src/components/power-selection/container/tests/route-validation.spec.js
@@ -1,0 +1,25 @@
+import Container from '../route-validation';
+
+jest.mock('Src/selectors', () => ({
+  characterBySlugSelector: jest.fn().mockReturnValue('characterBySlugSelector')
+}));
+
+jest.mock('../../route-validation', () => 'MockComponent');
+
+describe('PowerSelectionRouteValidation container', () => {
+  describe('#mapStateToProps', () => {
+    it('returns expected key/value pairings', () => {
+      expect(
+        Container.mapStateToProps(null, {
+          match: {
+            params: {
+              characterSlug: 'fake-slug'
+            }
+          }
+        })
+      ).toEqual({
+        character: 'characterBySlugSelector'
+      });
+    });
+  });
+});

--- a/src/components/power-selection/lazy.js
+++ b/src/components/power-selection/lazy.js
@@ -3,6 +3,6 @@ import { lazy } from 'react';
 export default lazy(() =>
   import(
     /* webpackChunkName: "power-selection" */
-    './container'
+    './container/route-validation'
   )
 );

--- a/src/components/power-selection/route-validation.js
+++ b/src/components/power-selection/route-validation.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import Immutable from 'immutable';
+import PageNotFound from 'Components/page-not-found/lazy';
+import PowerSelection from './container';
+
+const PowerValidationRouteValidation = ({ character }) => {
+  if (Immutable.Map.isMap(character)) return <PowerSelection />;
+  return <PageNotFound />;
+};
+
+PowerValidationRouteValidation.propTypes = {
+  character: ImmutablePropTypes.map
+};
+
+export default PowerValidationRouteValidation;

--- a/src/components/power-selection/tests/__snapshots__/route-validation.spec.js.snap
+++ b/src/components/power-selection/tests/__snapshots__/route-validation.spec.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PowerSelectionRouteValidation component when character is missing renders the PageNotFound component 1`] = `<MockPageNotFound />`;
+
+exports[`PowerSelectionRouteValidation component when character is present renders the PowerSelection component 1`] = `<MockPowerSelection />`;

--- a/src/components/power-selection/tests/route-validation.spec.js
+++ b/src/components/power-selection/tests/route-validation.spec.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import Immutable from 'immutable';
+import renderer from 'react-test-renderer';
+import PowerSelectionRouteValidation from '../route-validation';
+
+jest.mock('Components/page-not-found/lazy', () => 'MockPageNotFound');
+
+jest.mock('../container', () => 'MockPowerSelection');
+
+describe('PowerSelectionRouteValidation component', () => {
+  let testContext;
+
+  const renderComponent = (props = {}) => (
+    <PowerSelectionRouteValidation {...testContext.defaultProps} {...props} />
+  );
+
+  beforeEach(() => {
+    testContext = {};
+
+    testContext.defaultProps = {};
+  });
+
+  describe('when character is missing', () => {
+    beforeEach(() => {
+      testContext.component = renderer.create(renderComponent());
+    });
+
+    it('renders the PageNotFound component', () => {
+      expect(testContext.component).toMatchSnapshot();
+    });
+  });
+
+  describe('when character is present', () => {
+    beforeEach(() => {
+      testContext.component = renderer.create(
+        renderComponent({
+          character: Immutable.Map()
+        })
+      );
+    });
+
+    it('renders the PowerSelection component', () => {
+      expect(testContext.component).toMatchSnapshot();
+    });
+  });
+});

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -17,6 +17,11 @@ export const charactersDataSelector = createSelector(
   charactersReducerSelectors.dataSelector
 );
 
+export const characterBySlugSelector = (state, slug) => {
+  const characters = charactersDataSelector(state);
+  return characters.find((character) => character.get('slug') === slug);
+};
+
 const charactersRequestStatusSelector = createSelector(
   charactersSelector,
   charactersReducerSelectors.requestStatusSelector

--- a/src/tests/selectors.spec.js
+++ b/src/tests/selectors.spec.js
@@ -25,6 +25,29 @@ describe('Selectors', () => {
     });
   });
 
+  describe('#characterBySlugSelector', () => {
+    beforeEach(() => {
+      testContext.state = Immutable.fromJS({
+        characters: {
+          data: {
+            testKey: { slug: 'non-matching' },
+            fakeKey: { slug: 'matching' }
+          }
+        }
+      });
+    });
+
+    it('returns relevant record', () => {
+      expect(
+        selectors.characterBySlugSelector(testContext.state, 'matching')
+      ).toEqual(
+        Immutable.Map({
+          slug: 'matching'
+        })
+      );
+    });
+  });
+
   describe('#isInitialDataIncompleteSelector', () => {
     describe('when characters request is idle', () => {
       beforeEach(() => {


### PR DESCRIPTION
- Adding new selector to search characters for a specified slug.
- Adding new route validation container / component to render power selection or page not found accordingly.
- Updating lazy entry point for power selection to point at new route validation container.
- (Unrelated) Fixing a react hook linting issue where prop wasn't specified.