### PR TITLE
Upgrading to Node 13 for ESModules by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.5.0-alpine
+FROM node:13.8.0-alpine
 
 LABEL maintainer="Anthony Hastings <ar.hastings@gmail.com>"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: '3.7'
 services:
   web:
     build:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:css": "stylelint src/**/*.scss",
     "lint:js": "eslint --ext js --ext mjs server/ src/ support/ webpack/ jest.config.js postcss.config.js",
     "pretest": "npm run lint",
-    "start": "node --experimental-modules server/index.mjs",
+    "start": "node --experimental-json-modules server/index.mjs",
     "test": "jest",
     "webpack:dev-server": "webpack-dev-server --config=webpack/env.development.js",
     "webpack:production": "webpack --config=webpack/env.production.js --colors --progress",


### PR DESCRIPTION
- Updating compose file version to 3.7.
- Upgrading NodeJS version to 13.8.0 (where ESModules are enabled by default).
- Adding `experimental-json-modules` flag as JSON files aren't loadable by default within ESModules.