### PR TITLE
Adding jsconfig.json file and simplifying webpack CLI flags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ node_modules/
 dist/
 jest-cache/
 jest-coverage/
-jsconfig.json
 npm-debug.log
 .DS_Store
 .env

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "Api/*": ["src/api/*"],
+      "Components/*": ["src/components/*"],
+      "Constants/*": ["src/constants/*"],
+      "Images/*": ["images/*"],
+      "Reducers/*": ["src/reducers/*"],
+      "Src/*": ["src/*"]
+    }
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "node --experimental-json-modules server/index.mjs",
     "test": "jest",
     "webpack:dev-server": "webpack-dev-server --config=webpack/env.development.js",
-    "webpack:production": "webpack --config=webpack/env.production.js --colors --progress",
+    "webpack:production": "webpack --config=webpack/env.production.js",
     "webpack:stats": "npm run webpack:production -- --env.stats=true"
   },
   "husky": {


### PR DESCRIPTION
- Adding `jsconfig.json` file to allow VSCode to peek to files.
- Removing redundant flags on webpack command (`progress` wasn't useful, and `colors` is on by default).

More information:
https://create-react-app.dev/docs/importing-a-component/#absolute-imports
https://www.basefactor.com/configuring-aliases-in-webpack-vs-code-typescript-jest
https://code.visualstudio.com/docs/languages/jsconfig