### PR TITLE
Adding font-display swap for Google Fonts

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -15,7 +15,7 @@
     <link rel="icon" type="image/png" href="<%= require('../images/favicons/96x96.png') %>" sizes="96x96" />
     <link rel="icon" type="image/png" href="<%= require('../images/favicons/192x192.png') %>" sizes="192x192" />
     <link rel="manifest" href="<%= require('../manifests/manifest.webmanifest') %>" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Carrois+Gothic" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Carrois+Gothic&display=swap" />
     <% for (var stylesheet of htmlWebpackPlugin.files.css) { %>
       <link rel="stylesheet" href="<%= stylesheet %>" />
     <% } %>


### PR DESCRIPTION
Adding GET parameters for Google Fonts to be returned with `font-display: swap;` which ensures fonts are rendered immediately, sometimes using a fallback font while the web font file is still being downloaded. This gives us a performance speed boost due to the perception that things have arrived on the page quicker.