### PR TITLE
Manually moving webmanifest

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -14,7 +14,7 @@
     <link rel="icon" type="image/png" href="<%= require('../images/favicons/32x32.png') %>" sizes="32x32" />
     <link rel="icon" type="image/png" href="<%= require('../images/favicons/96x96.png') %>" sizes="96x96" />
     <link rel="icon" type="image/png" href="<%= require('../images/favicons/192x192.png') %>" sizes="192x192" />
-    <link rel="manifest" href="<%= require('../manifests/manifest.webmanifest') %>" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Carrois+Gothic&display=swap" />
     <% for (var stylesheet of htmlWebpackPlugin.files.css) { %>
       <link rel="stylesheet" href="<%= stylesheet %>" />

--- a/manifests/manifest.webmanifest
+++ b/manifests/manifest.webmanifest
@@ -4,17 +4,17 @@
   "display": "standalone",
   "icons": [
     {
-        "src": "../images/manifest/192x192.png",
+        "src": "/images/manifest/192x192.png",
         "sizes": "192x192",
         "type": "image/png"
     },
     {
-        "src": "../images/manifest/256x256.png",
+        "src": "/images/manifest/256x256.png",
         "sizes": "256x256",
         "type": "image/png"
     },
     {
-        "src": "../images/manifest/512x512.png",
+        "src": "/images/manifest/512x512.png",
         "sizes": "512x512",
         "type": "image/png"
     }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "stylelint-order": "4.0.0",
     "stylelint-scss": "3.17.2",
     "terser-webpack-plugin": "3.0.1",
-    "webmanifest-loader": "0.3.0",
     "webpack": "4.43.0",
     "webpack-bundle-analyzer": "3.7.0",
     "webpack-cli": "3.3.11",

--- a/support/paths.js
+++ b/support/paths.js
@@ -8,6 +8,7 @@ module.exports = {
   constants: path.join(projectRoot, 'src/constants'),
   dist: path.join(projectRoot, 'dist'),
   images: path.join(projectRoot, 'images'),
+  manifests: path.join(projectRoot, 'manifests'),
   reducers: path.join(projectRoot, 'src/reducers'),
   server: path.join(projectRoot, 'server'),
   src: path.join(projectRoot, 'src')

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -1,4 +1,5 @@
 const webpack = require('webpack');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -48,25 +49,9 @@ module.exports = function(environment) {
             {
               loader: 'file-loader',
               options: {
-                esModule: false, // TODO: REMOVE ONCE WEBMANIFEST-LOADER PLUGIN IS REPLACE WITH SOMETHING THAT SUPPORTS ES MODULES.
                 outputPath: 'images/',
                 name: isDev ? '[name].[ext]' : '[name].[contenthash].[ext]'
               }
-            }
-          ]
-        },
-        {
-          test: /\.webmanifest$/,
-          use: [
-            {
-              loader: 'file-loader',
-              options: {
-                esModule: false, // TODO: REMOVE ONCE WEBMANIFEST-LOADER PLUGIN IS REPLACE WITH SOMETHING THAT SUPPORTS ES MODULES.
-                name: isDev ? '[name].[ext]' : '[name].[contenthash].[ext]'
-              }
-            },
-            {
-              loader: 'webmanifest-loader'
             }
           ]
         }
@@ -93,7 +78,22 @@ module.exports = function(environment) {
       new MiniCssExtractPlugin({
         chunkFilename: isDev ? '[name].css' : 'css/[name].[contenthash].css',
         filename: isDev ? '[id].css' : 'css/[name].[contenthash].css'
-      })
+      }),
+      new CopyWebpackPlugin(
+        [
+          {
+            from: paths.manifests,
+            to: './'
+          },
+          {
+            from: `${paths.images}/manifest`,
+            to: 'images/manifest/'
+          }
+        ],
+        {
+          logLevel: 'debug'
+        }
+      )
     ],
     resolve: {
       alias: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2149,13 +2149,6 @@ async-throttle@^1.1.0:
   resolved "https://registry.yarnpkg.com/async-throttle/-/async-throttle-1.1.0.tgz#229e7f3fa7a2a797e86f360e6309a08224d4fa7a"
   integrity sha1-Ip5/P6eip5fobzYOYwmggiTU+no=
 
-async@^2.6.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
-  integrity sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==
-  dependencies:
-    lodash "^4.17.10"
-
 async@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
@@ -7589,11 +7582,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash._reinterpolate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
-  integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
-
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
@@ -7613,21 +7601,6 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
-
-lodash.template@^4.4.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
-  integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
-    lodash.templatesettings "^4.0.0"
-
-lodash.templatesettings@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz#e481310f049d3cf6d47e912ad09313b154f0fb33"
-  integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
 
 lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -12551,15 +12524,6 @@ webidl-conversions@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
-
-webmanifest-loader@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/webmanifest-loader/-/webmanifest-loader-0.3.0.tgz#fe4e68d5e7fdc3ac9b05e84d45050c54ef2990a4"
-  integrity sha512-tBym25SX04hbsJK+fi025KpRnCXGBrm/m9RkzUVvEc6awefRJb8vdn3xltAv3lc7nLKJlJa8WnGR5Z1J+5GuOQ==
-  dependencies:
-    async "^2.6.0"
-    loader-utils "^1.1.0"
-    lodash.template "^4.4.0"
 
 webpack-bundle-analyzer@3.7.0:
   version "3.7.0"


### PR DESCRIPTION
This PR removes `webmanifest-loader` which was formerly in charge of requiring and loading the associated image assets. The reason for this removal is because many webpack loaders are now supporting an `esModule` option, which is enabled to `true` by default. It ensures that file output is now `export default 'abc123.jpg` instead of `module.exports = 'abc123.jpg`.

Unfortunately `webmanifest-loader` blows up when it receives the ES Modules for the image assets, and no other webmanifest loader or plugin does the same job. It's easier to just manually move the assets myself and hard-code the paths. Image minification on production still takes effect.