### PR TITLE
Fixing image names with hash suffix.

### DIFF
--- a/webpack/base.js
+++ b/webpack/base.js
@@ -50,7 +50,7 @@ module.exports = function(environment) {
               loader: 'file-loader',
               options: {
                 outputPath: 'images/',
-                name: isDev ? '[name].[ext]' : '[name].[contenthash].[ext]'
+                name: '[name].[contenthash].[ext]'
               }
             }
           ]


### PR DESCRIPTION
Ensuring that file names are always output with a unique hash in their filename that's based on their content. This is because images aren't placed into folders; they're thrown into `dist/images` and because of this, we have conflicts on filenames such as `192x192.png` which refers to both a favicon and a web manifest image. One overwrites the other.

Now with content hashes in the file names, this collision problem is super unlikely.