### PR TITLE
Fixing favicon paths.

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -10,10 +10,10 @@
       }
     } %>
     <title>Dishonored 2: Power Calculator</title>
-    <link rel="icon" type="image/png" href="<%= require('../images/favicons/16x16.png') %>" sizes="16x16" />
-    <link rel="icon" type="image/png" href="<%= require('../images/favicons/32x32.png') %>" sizes="32x32" />
-    <link rel="icon" type="image/png" href="<%= require('../images/favicons/96x96.png') %>" sizes="96x96" />
-    <link rel="icon" type="image/png" href="<%= require('../images/favicons/192x192.png') %>" sizes="192x192" />
+    <link rel="icon" type="image/png" href="<%= require('../images/favicons/16x16.png').default %>" sizes="16x16" />
+    <link rel="icon" type="image/png" href="<%= require('../images/favicons/32x32.png').default %>" sizes="32x32" />
+    <link rel="icon" type="image/png" href="<%= require('../images/favicons/96x96.png').default %>" sizes="96x96" />
+    <link rel="icon" type="image/png" href="<%= require('../images/favicons/192x192.png').default %>" sizes="192x192" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Carrois+Gothic&display=swap" />
     <% for (var stylesheet of htmlWebpackPlugin.files.css) { %>
@@ -22,7 +22,6 @@
   </head>
   <body>
     <div id="application"></div>
-
     <% for (var script of htmlWebpackPlugin.files.js) { %>
       <script src="<%= script %>"></script>
     <% } %>


### PR DESCRIPTION
The recent move to the latest version of `file-loader` and how it exports ES Modules by default, broke my CommonJS loading of favicons within the `index.html` template. This PR adds `.default` to the CommonJS import, so it successfully loads the ES Module.