### PR TITLE
Moving to use optimization.moduleIds setting

### DIFF
--- a/webpack/base.js
+++ b/webpack/base.js
@@ -1,4 +1,3 @@
-const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
@@ -61,7 +60,6 @@ module.exports = function (environment) {
       new CleanWebpackPlugin({
         verbose: true,
       }),
-      new webpack.HashedModuleIdsPlugin(),
       new HtmlWebpackPlugin({
         filename: 'index.html',
         hash: false,

--- a/webpack/env.production.js
+++ b/webpack/env.production.js
@@ -53,6 +53,7 @@ module.exports = function (env = {}) {
           },
         },
       },
+      moduleIds: 'hashed',
       runtimeChunk: {
         name: 'manifest',
       },


### PR DESCRIPTION
For a long time, `HashedModuleIdsPlugin()` has had to be manually added in order to have webpack output hashes for Module IDs rather than rely on numeric sequencing. The [webpack caching guide](https://webpack.js.org/guides/caching/#module-identifiers) now refers to setting an `optimization.moduleIds` setting which, [internally calls `HashedModuleIdsPlugin`](https://github.com/webpack/webpack/blob/81cf088cd6a0231b94fa2399bd29294eccee1907/lib/WebpackOptionsApply.js#L362-L391).

Using the setting will ensure the complexity and logic gets hidden and enables us to just simply toggle a single configuration property.