### PR TITLE
Noticket minor fixes

### DIFF
--- a/src/reducers/characters/index.js
+++ b/src/reducers/characters/index.js
@@ -14,7 +14,6 @@ export const getCharactersPending = () => ({
 
 export const getCharactersFailure = () => ({
   type: GET_CHARACTERS_FAILURE,
-  error: true,
 });
 
 export const getCharactersSuccess = (characters) => ({

--- a/src/reducers/characters/tests/index.spec.js
+++ b/src/reducers/characters/tests/index.spec.js
@@ -158,7 +158,6 @@ describe('Characters action creators', () => {
           { type: GET_CHARACTERS_PENDING },
           {
             type: GET_CHARACTERS_FAILURE,
-            error: true,
           },
         ]);
       });
@@ -177,7 +176,6 @@ describe('Characters action creators', () => {
     it('creates an action', () => {
       expect(getCharactersFailure()).toEqual({
         type: GET_CHARACTERS_FAILURE,
-        error: true,
       });
     });
   });

--- a/src/reducers/powers/index.js
+++ b/src/reducers/powers/index.js
@@ -14,7 +14,6 @@ export const getPowersPending = () => ({
 
 export const getPowersFailure = () => ({
   type: GET_POWERS_FAILURE,
-  error: true,
 });
 
 export const getPowersSuccess = (powers) => ({

--- a/src/reducers/powers/selectors.js
+++ b/src/reducers/powers/selectors.js
@@ -1,1 +1,3 @@
+export const dataSelector = (state) => state.get('data');
+
 export const requestStatusSelector = (state) => state.get('requestStatus');

--- a/src/reducers/powers/tests/index.spec.js
+++ b/src/reducers/powers/tests/index.spec.js
@@ -164,7 +164,6 @@ describe('Powers action creators', () => {
           { type: GET_POWERS_PENDING },
           {
             type: GET_POWERS_FAILURE,
-            error: true,
           },
         ]);
       });
@@ -183,7 +182,6 @@ describe('Powers action creators', () => {
     it('creates an action', () => {
       expect(getPowersFailure()).toEqual({
         type: GET_POWERS_FAILURE,
-        error: true,
       });
     });
   });

--- a/src/reducers/powers/tests/selectors.spec.js
+++ b/src/reducers/powers/tests/selectors.spec.js
@@ -8,6 +8,18 @@ describe('Powers selectors', () => {
     testContext = {};
   });
 
+  describe('#dataSelector', () => {
+    beforeEach(() => {
+      testContext.state = Immutable.fromJS({
+        data: 'foo-bar',
+      });
+    });
+
+    it('returns value of corresponding key', () => {
+      expect(selectors.dataSelector(testContext.state)).toEqual('foo-bar');
+    });
+  });
+
   describe('#requestStatusSelector', () => {
     beforeEach(() => {
       testContext.state = Immutable.fromJS({

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -10,28 +10,31 @@ const isRequestIncomplete = (requestStatus) =>
 const hasRequestFailed = (requestStatus) =>
   requestStatus === requestStatuses.failure;
 
+const filterTopLeverPowersList = (records) =>
+  records.filter((record) => record.get('parentPowerId') === null).toList();
+
 const charactersSelector = (state) => state.get('characters', Immutable.Map());
+
+const powersSelector = (state) => state.get('powers', Immutable.Map());
 
 export const charactersDataSelector = createSelector(
   charactersSelector,
   charactersReducerSelectors.dataSelector
 );
 
-export const characterBySlugSelector = (state, slug) => {
-  const characters = charactersDataSelector(state);
-  return characters.find((character) => character.get('slug') === slug);
-};
-
 const charactersRequestStatusSelector = createSelector(
   charactersSelector,
   charactersReducerSelectors.requestStatusSelector
 );
 
-const powersSelector = (state) => state.get('powers', Immutable.Map());
-
 const powersRequestStatusSelector = createSelector(
   powersSelector,
   powersReducerSelectors.requestStatusSelector
+);
+
+const powersDataSelector = createSelector(
+  powersSelector,
+  powersReducerSelectors.dataSelector
 );
 
 export const isInitialDataIncompleteSelector = createSelector(
@@ -45,3 +48,38 @@ export const hasInitialDataFailedSelector = createSelector(
   powersRequestStatusSelector,
   (...statuses) => statuses.some(hasRequestFailed)
 );
+
+export const characterBySlugSelector = (state, slug) => {
+  const characters = charactersDataSelector(state);
+  return characters.find((character) => character.get('slug') === slug);
+};
+
+const enhancementRecordsSelector = createSelector(powersDataSelector, (data) =>
+  data.filter((record) => record.get('type') === 'enhancement')
+);
+
+const powerRecordsSelector = createSelector(powersDataSelector, (data) =>
+  data.filter((record) => record.get('type') === 'power')
+);
+
+export const topLevelEnhancementsSelector = createSelector(
+  enhancementRecordsSelector,
+  filterTopLeverPowersList
+);
+
+const topLevelPowersSelector = createSelector(
+  powerRecordsSelector,
+  filterTopLeverPowersList
+);
+
+export const topLevelPowersByCharacterSlugSelector = (state, characterSlug) => {
+  const character = characterBySlugSelector(state, characterSlug);
+
+  return topLevelPowersSelector(state)
+    .filter((power) => {
+      const belongsTo = power.get('characterId') === character.get('id');
+      const belongsToAll = power.get('characterId') === null;
+      return belongsTo || belongsToAll;
+    })
+    .toList();
+};

--- a/src/tests/selectors.spec.js
+++ b/src/tests/selectors.spec.js
@@ -25,6 +25,74 @@ describe('Selectors', () => {
     });
   });
 
+  describe('#isInitialDataIncompleteSelector', () => {
+    describe.each([
+      ['characters', 'idle'],
+      ['characters', 'pending'],
+      ['powers', 'idle'],
+      ['powers', 'pending'],
+    ])('when %s request is %s', (dataType, status) => {
+      beforeEach(() => {
+        testContext.state = Immutable.fromJS({
+          [dataType]: {
+            requestStatus: requestStatuses[status],
+          },
+        });
+      });
+
+      it('returns true', () => {
+        expect(
+          selectors.isInitialDataIncompleteSelector(testContext.state)
+        ).toEqual(true);
+      });
+    });
+
+    describe('when neither requests are pending nor idle', () => {
+      beforeEach(() => {
+        testContext.state = Immutable.Map();
+      });
+
+      it('returns false', () => {
+        expect(
+          selectors.isInitialDataIncompleteSelector(testContext.state)
+        ).toEqual(false);
+      });
+    });
+  });
+
+  describe('#hasInitialDataFailedSelector', () => {
+    describe.each([
+      ['characters', 'failure'],
+      ['powers', 'failure'],
+    ])('when %s request is %s', (dataType, status) => {
+      beforeEach(() => {
+        testContext.state = Immutable.fromJS({
+          [dataType]: {
+            requestStatus: requestStatuses[status],
+          },
+        });
+      });
+
+      it('returns true', () => {
+        expect(
+          selectors.hasInitialDataFailedSelector(testContext.state)
+        ).toEqual(true);
+      });
+    });
+
+    describe('when neither request has failed', () => {
+      beforeEach(() => {
+        testContext.state = Immutable.Map();
+      });
+
+      it('returns false', () => {
+        expect(
+          selectors.hasInitialDataFailedSelector(testContext.state)
+        ).toEqual(false);
+      });
+    });
+  });
+
   describe('#characterBySlugSelector', () => {
     beforeEach(() => {
       testContext.state = Immutable.fromJS({
@@ -48,127 +116,118 @@ describe('Selectors', () => {
     });
   });
 
-  describe('#isInitialDataIncompleteSelector', () => {
-    describe('when characters request is idle', () => {
-      beforeEach(() => {
-        testContext.state = Immutable.fromJS({
-          characters: {
-            requestStatus: requestStatuses.idle,
-          },
-        });
-      });
-
-      it('returns true', () => {
-        expect(
-          selectors.isInitialDataIncompleteSelector(testContext.state)
-        ).toEqual(true);
-      });
-    });
-
-    describe('when characters request is pending', () => {
-      beforeEach(() => {
-        testContext.state = Immutable.fromJS({
-          characters: {
-            requestStatus: requestStatuses.pending,
-          },
-        });
-      });
-
-      it('returns true', () => {
-        expect(
-          selectors.isInitialDataIncompleteSelector(testContext.state)
-        ).toEqual(true);
+  describe('#topLevelEnhancementsSelector', () => {
+    beforeEach(() => {
+      testContext.state = Immutable.fromJS({
+        powers: {
+          data: [
+            {
+              id: 1,
+              parentPowerId: null,
+              type: 'enhancement',
+              name: 'Top-level Enhancement',
+            },
+            {
+              id: 2,
+              parentPowerId: 1,
+              type: 'enhancement',
+              name: 'Sub-level Enhancement',
+            },
+            {
+              id: 3,
+              parentPowerId: null,
+              type: 'power',
+              name: 'Top-level Power',
+            },
+          ],
+        },
       });
     });
 
-    describe('when powers request is idle', () => {
-      beforeEach(() => {
-        testContext.state = Immutable.fromJS({
-          powers: {
-            requestStatus: requestStatuses.idle,
+    it('returns Immutable List of top-level enhancements', () => {
+      expect(selectors.topLevelEnhancementsSelector(testContext.state)).toEqual(
+        Immutable.fromJS([
+          {
+            id: 1,
+            parentPowerId: null,
+            type: 'enhancement',
+            name: 'Top-level Enhancement',
           },
-        });
-      });
-
-      it('returns true', () => {
-        expect(
-          selectors.isInitialDataIncompleteSelector(testContext.state)
-        ).toEqual(true);
-      });
-    });
-
-    describe('when powers request is pending', () => {
-      beforeEach(() => {
-        testContext.state = Immutable.fromJS({
-          powers: {
-            requestStatus: requestStatuses.pending,
-          },
-        });
-      });
-
-      it('returns true', () => {
-        expect(
-          selectors.isInitialDataIncompleteSelector(testContext.state)
-        ).toEqual(true);
-      });
-    });
-
-    describe('when neither request is pending nor idle', () => {
-      beforeEach(() => {
-        testContext.state = Immutable.Map();
-      });
-
-      it('returns false', () => {
-        expect(
-          selectors.isInitialDataIncompleteSelector(testContext.state)
-        ).toEqual(false);
-      });
+        ])
+      );
     });
   });
 
-  describe('#hasInitialDataFailedSelector', () => {
-    describe('when characters request is failure', () => {
-      beforeEach(() => {
-        testContext.state = Immutable.fromJS({
-          characters: {
-            requestStatus: requestStatuses.failure,
+  describe('#topLevelPowersByCharacterSlugSelector', () => {
+    beforeEach(() => {
+      testContext.state = Immutable.fromJS({
+        characters: {
+          data: {
+            'character-123': {
+              id: 'character-123',
+              slug: 'fake-character-slug',
+            },
           },
-        });
-      });
-
-      it('returns true', () => {
-        expect(
-          selectors.hasInitialDataFailedSelector(testContext.state)
-        ).toEqual(true);
+        },
+        powers: {
+          data: {
+            'power-1': {
+              id: 'power-1',
+              characterId: null,
+              parentPowerId: null,
+              type: 'power',
+              name: 'Top-level Generic Power',
+            },
+            'power-2': {
+              id: 'power-2',
+              characterId: 'character-123',
+              parentPowerId: null,
+              type: 'power',
+              name: 'Top-level Relevant Power',
+            },
+            'power-3': {
+              id: 'power-3',
+              characterId: 456,
+              parentPowerId: null,
+              type: 'power',
+              name: 'Top-level Irrelevant Power',
+            },
+            'power-4': {
+              id: 'power-4',
+              characterId: null,
+              parentPowerId: null,
+              type: 'enhancement',
+              name: 'Top-level Enhancement',
+            },
+          },
+        },
       });
     });
 
-    describe('when powers request is failure', () => {
-      beforeEach(() => {
-        testContext.state = Immutable.fromJS({
-          powers: {
-            requestStatus: requestStatuses.failure,
+    it('returns Immutable List of top-level owned or generic powers', () => {
+      expect(
+        selectors.topLevelPowersByCharacterSlugSelector(
+          testContext.state,
+          'fake-character-slug'
+        )
+      ).toEqual(
+        Immutable.fromJS([
+          {
+            id: 'power-1',
+            characterId: null,
+            parentPowerId: null,
+            type: 'power',
+            name: 'Top-level Generic Power',
           },
-        });
-      });
-
-      it('returns true', () => {
-        expect(
-          selectors.hasInitialDataFailedSelector(testContext.state)
-        ).toEqual(true);
-      });
-    });
-
-    describe('when neither request has failed', () => {
-      beforeEach(() => {
-        testContext.state = Immutable.Map();
-      });
-
-      it('returns false', () => {
-        expect(
-          selectors.hasInitialDataFailedSelector(testContext.state)
-        ).toEqual(false);
-      });
+          {
+            id: 'power-2',
+            characterId: 'character-123',
+            parentPowerId: null,
+            type: 'power',
+            name: 'Top-level Relevant Power',
+          },
+        ])
+      );
     });
   });
 });


### PR DESCRIPTION
- Removing unused `error` keys from action creators.
- Adding missing `dataSelector` to Powers reducer.
- DRYing global selectors and adding missing tests.