### PR TITLE
Moving lazy loading calls outside of components

### DIFF
--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -1,14 +1,32 @@
-import React, { Suspense, useEffect } from 'react';
+import React, { Suspense, useEffect, lazy } from 'react';
 import PropTypes from 'prop-types';
 import { Switch, Route, Link } from 'react-router-dom';
 import 'normalize.css';
 import './stylesheets/index.scss';
-import CharacterSelection from 'Components/character-selection/lazy';
 import Loader from 'Components/loader';
-import PageNotFound from 'Components/page-not-found/lazy';
-import PowerSelectionRouteValidation from 'Components/power-selection/lazy';
 import logo660 from 'Images/logo/660x90.png';
 import logo1320 from 'Images/logo/1320x180.png';
+
+const CharacterSelection = lazy(() =>
+  import(
+    /* webpackChunkName: "character-selection" */
+    'Components/character-selection/container'
+  )
+);
+
+const PageNotFound = lazy(() =>
+  import(
+    /* webpackChunkName: "page-not-found" */
+    'Components/page-not-found'
+  )
+);
+
+const PowerSelectionRouteValidation = lazy(() =>
+  import(
+    /* webpackChunkName: "power-selection" */
+    'Components/power-selection/container/route-validation'
+  )
+);
 
 const namespace = 'app';
 

--- a/src/components/character-selection/lazy.js
+++ b/src/components/character-selection/lazy.js
@@ -1,8 +1,0 @@
-import { lazy } from 'react';
-
-export default lazy(() =>
-  import(
-    /* webpackChunkName: "character-selection" */
-    './container'
-  )
-);

--- a/src/components/page-not-found/lazy.js
+++ b/src/components/page-not-found/lazy.js
@@ -1,8 +1,0 @@
-import { lazy } from 'react';
-
-export default lazy(() =>
-  import(
-    /* webpackChunkName: "page-not-found" */
-    './'
-  )
-);

--- a/src/components/power-selection/lazy.js
+++ b/src/components/power-selection/lazy.js
@@ -1,8 +1,0 @@
-import { lazy } from 'react';
-
-export default lazy(() =>
-  import(
-    /* webpackChunkName: "power-selection" */
-    './container/route-validation'
-  )
-);


### PR DESCRIPTION
Current thinking is that the components shouldn't be supplying a lazy loaded version of themselves; that's up to the consuming parent module to figure out. Said parent can decide how best to load the component, and act accordingly. I don't believe it's the child components job to give a lazy version of itself.