### PR TITLE
Lazy loading PageNotFound component

### DIFF
--- a/src/components/power-selection/route-validation.js
+++ b/src/components/power-selection/route-validation.js
@@ -1,12 +1,18 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import Immutable from 'immutable';
-import PageNotFound from 'Components/page-not-found/lazy';
+import Loader from 'Components/loader';
 import PowerSelection from './container';
+
+const PageNotFound = lazy(() => import('Components/page-not-found'));
 
 const PowerValidationRouteValidation = ({ character }) => {
   if (Immutable.Map.isMap(character)) return <PowerSelection />;
-  return <PageNotFound />;
+  return (
+    <Suspense fallback={<Loader showLoader={true} />}>
+      <PageNotFound />
+    </Suspense>
+  );
 };
 
 PowerValidationRouteValidation.propTypes = {


### PR DESCRIPTION
Ensuring that the `PageNotFound` component is lazy loaded. I don't specify a chunk name here as Webpack seems to reuse the chunk for `PageNotFound` first defined via the lazy import within `App` component.