### PR TITLE
Decoupling linting from testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "lint": "yarn run lint:css && yarn run lint:js",
     "lint:css": "stylelint src/**/*.scss",
     "lint:js": "eslint --ext js --ext mjs server/ src/ support/ webpack/ jest.config.mjs postcss.config.js",
-    "pretest": "yarn run lint",
     "start": "node --experimental-json-modules server/index.mjs",
     "test": "jest",
     "webpack:dev-server": "webpack-dev-server --config=webpack/env.development.js",

--- a/scripts/upload_coverage.sh
+++ b/scripts/upload_coverage.sh
@@ -1,3 +1,3 @@
 #/bin/bash
 
-npm test && bash -c "bash <(curl -s https://codecov.io/bash)"
+yarn run lint && yarn test && bash -c "bash <(curl -s https://codecov.io/bash)"


### PR DESCRIPTION
It becomes increasingly annoying whenever linting occurs as a result of running the test command. They should be mutually exclusive, as committing will run linting on the staged files, and CI already runs linting before testing.