### PR TITLE
Minor tweaks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,8 +9,7 @@
     "ecmaVersion": 2020,
     "sourceType": "module",
     "ecmaFeatures": {
-      "jsx": true,
-      "experimentalObjectRestSpread": true
+      "jsx": true
     }
   },
   "plugins": [
@@ -49,7 +48,7 @@
   "overrides": [
     {
       "files": [
-        "**/__mocks__/*.js",
+        "**/__mocks__/*.{js,mjs}",
         "**/*.spec.{js,mjs}"
       ],
       "env": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:13.8.0-alpine
+FROM node:14.13.0-alpine
 
 LABEL maintainer="Anthony Hastings <ar.hastings@gmail.com>"
 

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ start-tests-upload-coverage:
 	docker-compose run ${ci_env} --rm web ./scripts/upload_coverage.sh
 
 start-tests-watch:
-	docker-compose run --rm web yarn test -- --watchAll
+	docker-compose run --rm web yarn test --watchAll


### PR DESCRIPTION
- Upgrading to Node 14 which removes the deprecation warning that appeared in Node 13 when using ES Modules:
```
dishonored2-web | (node:27) ExperimentalWarning: The ESM module loader is experimental.
```
- Removing redundant `--` from test command.
- Removing `experimentalObjectRestSpread` as it's deprecated.
- Updating `js` patterns to also include `mjs`.