### PR TITLE
Adding docker multi-stage builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,22 +3,26 @@ SHELL:=/bin/bash
 help:
 	@echo "start-dev - Starts webpack-dev-server for local development."
 	@echo "start-production - Starts serving production assets via Express.js."
+	@echo "start-tests - Runs linting."
 	@echo "start-tests - Runs the test suite."
 	@echo "start-tests-upload-coverage - Runs the test suite and posts results."
 	@echo "start-tests-watch - Runs the test suite in watch mode."
 
 start-dev:
-	docker-compose run --rm --service-ports web yarn run webpack:dev-server
+	docker-compose run --rm --service-ports dev
 
 start-production:
 	docker-compose up web
 
+start-lint:
+	docker-compose run --rm dev yarn run lint
+
 start-tests:
-	docker-compose run --rm web yarn test
+	docker-compose run --rm dev yarn test
 
 start-tests-upload-coverage:
 	$(eval ci_env=$(shell bash <(curl -s https://codecov.io/env)))
-	docker-compose run ${ci_env} --rm web ./scripts/upload_coverage.sh
+	docker-compose run ${ci_env} --rm dev ./scripts/upload_coverage.sh
 
 start-tests-watch:
-	docker-compose run --rm web yarn test --watchAll
+	docker-compose run --rm dev yarn test --watchAll

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,19 @@ services:
       context: ./
       args:
         - GOOGLE_SITE_VERIFICATION_TOKEN
-    command: sh -c "yarn start"
-    container_name: dishonored2-web
+    environment:
+      - GOOGLE_SITE_VERIFICATION_TOKEN
+      - PORT
+    ports:
+      - ${PORT}:${PORT}
+
+  dev:
+    build:
+      context: ./
+      target: base
+      args:
+        - GOOGLE_SITE_VERIFICATION_TOKEN
+    command: sh -c "yarn run webpack:dev-server"
     environment:
       - CODECOV_TOKEN
       - GOOGLE_SITE_VERIFICATION_TOKEN
@@ -14,11 +25,11 @@ services:
     ports:
       - ${PORT}:${PORT}
     volumes:
-      - ./html:/dishonored2-power-calculator/html
-      - ./images:/dishonored2-power-calculator/images
-      - ./manifests:/dishonored2-power-calculator/manifests
-      - ./scripts:/dishonored2-power-calculator/scripts
-      - ./server:/dishonored2-power-calculator/server
-      - ./src:/dishonored2-power-calculator/src
-      - ./support:/dishonored2-power-calculator/support
-      - ./webpack:/dishonored2-power-calculator/webpack
+      - ./html:/dishonored/html
+      - ./images:/dishonored/images
+      - ./manifests:/dishonored/manifests
+      - ./scripts:/dishonored/scripts
+      - ./server:/dishonored/server
+      - ./src:/dishonored/src
+      - ./support:/dishonored/support
+      - ./webpack:/dishonored/webpack


### PR DESCRIPTION
This PR adds multi-stage builds to the docker image. This helps separate the process of building the assets from serving the assets. The reason for this is because the image for serving the assets can be dramatically smaller in size.

Practical results from this PR:
**Before:** 417MB
**After:** 139MB

The production image merely copies over the build assets from the base image, along with the necessary files to run the Express application. It then installs only the production dependencies and starts the application. The lack of binaries and dev dependencies are the reason for the size reduction.

The production image also copies files to, and runs them as the packaged `node` user that comes with official NodeJS docker images. Docker runs everything as the root user by default, and it's a best practice to utilize the `node` user instead.