### PR TITLE
Adding browserslist scripts and updating database

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,2 +1,3 @@
 > 0.5%
+last 2 versions
 not dead

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ jest-cache/
 jest-coverage/
 npm-debug.log
 package-lock.json
+yarn-error.log
 .DS_Store
 .env

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "main": "server/index.mjs",
   "scripts": {
     "build": "yarn run webpack:production",
+    "browserslist:debug": "browserslist --config=.browserslistrc",
+    "browserslist:update": "npx browserslist@latest --update-db && yarn list caniuse-lite",
     "eslint-check": "eslint --print-config src/components/app/container/index.js | eslint-config-prettier-check",
     "lint": "time npm-run-all --parallel --print-label --continue-on-error lint:*",
     "lint:css": "time stylelint src/**/*.scss",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3249,24 +3249,24 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0:
-  version "1.0.30000989"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz#b9193e293ccf7e4426c5245134b8f2a56c0ac4b9"
-  integrity sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==
+  version "1.0.30001148"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz"
+  integrity sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==
 
 caniuse-lite@^1.0.30000984:
-  version "1.0.30000988"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000988.tgz#742f35ec1b8b75b9628d705d7652eea1fef983db"
-  integrity sha512-lPj3T8poYrRc/bniW5SQPND3GRtSrQdUM/R4mCYTbZxyi3jQiggLvZH4+BYUuX0t4TXjU+vMM7KFDQg+rSzZUQ==
+  version "1.0.30001148"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz"
+  integrity sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==
 
 caniuse-lite@^1.0.30001039, caniuse-lite@^1.0.30001043:
-  version "1.0.30001054"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001054.tgz#7e82fc42d927980b0ce1426c4813df12381e1a75"
-  integrity sha512-jiKlTI6Ur8Kjfj8z0muGrV6FscpRvefcQVPSuMuXnvRCfExU7zlVLNjmOz1TnurWgUrAY7MMmjyy+uTgIl1XHw==
+  version "1.0.30001148"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz"
+  integrity sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==
 
 caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001135:
-  version "1.0.30001143"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001143.tgz#560f2cfb9f313d1d7e52eb8dac0e4e36c8821c0d"
-  integrity sha512-p/PO5YbwmCpBJPxjOiKBvAlUPgF8dExhfEpnsH+ys4N/791WHrYrGg0cyHiAURl5hSbx5vIcjKmQAP6sHDYH3w==
+  version "1.0.30001148"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz"
+  integrity sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Adding `yarn-error.log` to ignored files from source control.
- Adding `browserslist:debug` script that outputs targeted browsers and versions based on settings within `.browserslistrc`.
- Adding `browserslist:update` script that updates all references to `caniuse-lite` in `yarn.lock` to the latest version.
- Updating `.browserslistrc` to closer match the packages defaults. It now includes `last 2 versions` as it was often ignoring support for the latest version of a browser, as it's usage may not have yet exceeded over 0.5% global usage, as our config desires.

| Old Support       | New Support       |
| ----------------- | ----------------- |
| and_chr 85        | and_chr 85        |
| and_uc 12.12      | and_ff 79         |
| chrome 85         | and_qq 10.4       |
| chrome 84         | and_uc 12.12      |
| edge 85           | android 81        |
| firefox 81        | baidu 7.12        |
| firefox 80        | chrome 86         |
| ie 11             | chrome 85         |
| ios_saf 14        | chrome 84         |
| ios_saf 13.4-13.7 | edge 86           |
| ios_saf 13.3      | edge 85           |
| ios_saf 12.2-12.4 | firefox 81        |
| op_mini all       | firefox 80        |
| opera 70          | ie 11             |
| safari 13.1       | ios_saf 14        |
| samsung 12.0      | ios_saf 13.4-13.7 |
|                   | ios_saf 13.3      |
|                   | ios_saf 12.2-12.4 |
|                   | kaios 2.5         |
|                   | op_mini all       |
|                   | op_mob 59         |
|                   | opera 71          |
|                   | opera 70          |
|                   | safari 14         |
|                   | safari 13.1       |
|                   | samsung 12.0      |
|                   | samsung 11.1-11.2 |