### PR TITLE
Removing redux-mock-store package

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "postcss-loader": "3.0.0",
     "prettier": "2.1.2",
     "react-test-renderer": "17.0.1",
-    "redux-mock-store": "1.5.4",
     "sass-loader": "8.0.2",
     "snapshot-diff": "0.8.0",
     "stylelint": "13.7.2",

--- a/src/reducers/characters/tests/index.spec.js
+++ b/src/reducers/characters/tests/index.spec.js
@@ -1,8 +1,6 @@
 import Immutable from 'immutable';
-import configureMockStore from 'redux-mock-store';
 import getCharactersSuccessResponse from 'Api/sample-responses/get-characters-success';
 import requestStatuses from 'Constants/request-statuses';
-import { middleware } from '../../../store';
 import { getCharacters as getCharactersMock } from 'Api/characters';
 import reducer, {
   GET_CHARACTERS_PENDING,
@@ -87,70 +85,56 @@ describe('Characters reducer', () => {
 
   describe('action creators', () => {
     describe('#getCharacters', () => {
-      beforeEach(() => {
-        testContext.mockStore = configureMockStore(middleware)();
-      });
-
-      describe('when the request triggers', () => {
-        beforeEach(async () => {
-          getCharactersMock.mockResolvedValue();
-          await testContext.mockStore.dispatch(getCharacters());
-        });
-
-        it('fires a requested action', () => {
-          expect(testContext.mockStore.getActions()[0]).toEqual({
-            type: GET_CHARACTERS_PENDING,
-          });
-        });
-      });
-
       describe('when the request succeeds', () => {
         beforeEach(async () => {
+          testContext.mockDispatch = jest.fn();
           getCharactersMock.mockResolvedValue({
             data: getCharactersSuccessResponse,
           });
 
-          await testContext.mockStore.dispatch(getCharacters());
+          await getCharacters()(testContext.mockDispatch);
         });
 
         it('fires a requested action and a success action', () => {
-          expect(testContext.mockStore.getActions()).toEqual([
-            { type: GET_CHARACTERS_PENDING },
-            {
-              type: GET_CHARACTERS_SUCCESS,
-              payload: {
-                characters: Immutable.fromJS({
-                  'fake-uuid-01': {
-                    id: 'fake-uuid-01',
-                    slug: 'fake-slug-01',
-                    name: 'fake-name-01',
-                    description: 'fake-description-01',
-                  },
-                  'fake-uuid-02': {
-                    id: 'fake-uuid-02',
-                    slug: 'fake-slug-02',
-                    name: 'fake-name-02',
-                    description: 'fake-description-02',
-                  },
-                }),
+          expect(testContext.mockDispatch.mock.calls).toEqual([
+            [{ type: GET_CHARACTERS_PENDING }],
+            [
+              {
+                type: GET_CHARACTERS_SUCCESS,
+                payload: {
+                  characters: Immutable.fromJS({
+                    'fake-uuid-01': {
+                      id: 'fake-uuid-01',
+                      slug: 'fake-slug-01',
+                      name: 'fake-name-01',
+                      description: 'fake-description-01',
+                    },
+                    'fake-uuid-02': {
+                      id: 'fake-uuid-02',
+                      slug: 'fake-slug-02',
+                      name: 'fake-name-02',
+                      description: 'fake-description-02',
+                    },
+                  }),
+                },
               },
-            },
+            ],
           ]);
         });
       });
 
       describe('when the request fails', () => {
         beforeEach(async () => {
+          testContext.mockDispatch = jest.fn();
           getCharactersMock.mockRejectedValue();
-          await testContext.mockStore.dispatch(getCharacters());
+
+          await getCharacters()(testContext.mockDispatch);
         });
 
         it('fires a requested action and a failure action', () => {
-          expect(testContext.mockStore.getActions()).toEqual([
-            { type: GET_CHARACTERS_PENDING },
-            {
-              type: GET_CHARACTERS_FAILURE,
-            },
+          expect(testContext.mockDispatch.mock.calls).toEqual([
+            [{ type: GET_CHARACTERS_PENDING }],
+            [{ type: GET_CHARACTERS_FAILURE }],
           ]);
         });
       });

--- a/src/reducers/powers/tests/index.spec.js
+++ b/src/reducers/powers/tests/index.spec.js
@@ -1,8 +1,6 @@
 import Immutable from 'immutable';
-import configureMockStore from 'redux-mock-store';
 import getPowersSuccessResponse from 'Api/sample-responses/get-powers-success';
 import requestStatuses from 'Constants/request-statuses';
-import { middleware } from '../../../store';
 import { getPowers as getPowersMock } from 'Api/powers';
 import reducer, {
   GET_POWERS_PENDING,
@@ -87,75 +85,62 @@ describe('Powers reducer', () => {
 
   describe('action creators', () => {
     describe('#getPowers', () => {
-      beforeEach(() => {
-        testContext.mockStore = configureMockStore(middleware)();
-      });
-
-      describe('when the request triggers', () => {
-        beforeEach(async () => {
-          getPowersMock.mockResolvedValue();
-          await testContext.mockStore.dispatch(getPowers());
-        });
-
-        it('fires a requested action', () => {
-          expect(testContext.mockStore.getActions()[0]).toEqual({
-            type: GET_POWERS_PENDING,
-          });
-        });
-      });
-
       describe('when the request succeeds', () => {
         beforeEach(async () => {
+          testContext.mockDispatch = jest.fn();
           getPowersMock.mockResolvedValue({
             data: getPowersSuccessResponse,
           });
-          await testContext.mockStore.dispatch(getPowers());
+
+          await getPowers()(testContext.mockDispatch);
         });
 
         it('fires a requested action and a success action', () => {
-          expect(testContext.mockStore.getActions()).toEqual([
-            { type: GET_POWERS_PENDING },
-            {
-              type: GET_POWERS_SUCCESS,
-              payload: {
-                powers: Immutable.fromJS({
-                  'fake-uuid-01': {
-                    id: 'fake-uuid-01',
-                    parentPowerId: 'fake-parent-power-id-01',
-                    characterId: 'fake-character-id-01',
-                    type: 'fake-type-01',
-                    name: 'fake-name-01',
-                    description: 'fake-description-01',
-                    cost: 1,
-                  },
-                  'fake-uuid-02': {
-                    id: 'fake-uuid-02',
-                    parentPowerId: 'fake-parent-power-id-02',
-                    characterId: 'fake-character-id-02',
-                    type: 'fake-type-02',
-                    name: 'fake-name-02',
-                    description: 'fake-description-02',
-                    cost: 2,
-                  },
-                }),
+          expect(testContext.mockDispatch.mock.calls).toEqual([
+            [{ type: GET_POWERS_PENDING }],
+            [
+              {
+                type: GET_POWERS_SUCCESS,
+                payload: {
+                  powers: Immutable.fromJS({
+                    'fake-uuid-01': {
+                      id: 'fake-uuid-01',
+                      parentPowerId: 'fake-parent-power-id-01',
+                      characterId: 'fake-character-id-01',
+                      type: 'fake-type-01',
+                      name: 'fake-name-01',
+                      description: 'fake-description-01',
+                      cost: 1,
+                    },
+                    'fake-uuid-02': {
+                      id: 'fake-uuid-02',
+                      parentPowerId: 'fake-parent-power-id-02',
+                      characterId: 'fake-character-id-02',
+                      type: 'fake-type-02',
+                      name: 'fake-name-02',
+                      description: 'fake-description-02',
+                      cost: 2,
+                    },
+                  }),
+                },
               },
-            },
+            ],
           ]);
         });
       });
 
       describe('when the request fails', () => {
         beforeEach(async () => {
+          testContext.mockDispatch = jest.fn();
           getPowersMock.mockRejectedValue();
-          await testContext.mockStore.dispatch(getPowers());
+
+          await getPowers()(testContext.mockDispatch);
         });
 
         it('fires a requested action and a failure action', () => {
-          expect(testContext.mockStore.getActions()).toEqual([
-            { type: GET_POWERS_PENDING },
-            {
-              type: GET_POWERS_FAILURE,
-            },
+          expect(testContext.mockDispatch.mock.calls).toEqual([
+            [{ type: GET_POWERS_PENDING }],
+            [{ type: GET_POWERS_FAILURE }],
           ]);
         });
       });

--- a/src/store.js
+++ b/src/store.js
@@ -6,7 +6,7 @@ import thunk from 'redux-thunk';
 import characters from 'Reducers/characters';
 import powers from 'Reducers/powers';
 
-export const middleware = [thunk];
+const middleware = [thunk];
 
 const appliedMiddleware = applyMiddleware(...middleware);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8092,11 +8092,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash.isplainobject@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
-  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
-
 lodash.map@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
@@ -10753,13 +10748,6 @@ redux-immutable@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/redux-immutable/-/redux-immutable-4.0.0.tgz#3a1a32df66366462b63691f0e1dc35e472bbc9f3"
   integrity sha1-Ohoy32Y2ZGK2NpHw4dw15HK7yfM=
-
-redux-mock-store@1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.4.tgz#90d02495fd918ddbaa96b83aef626287c9ab5872"
-  integrity sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==
-  dependencies:
-    lodash.isplainobject "^4.0.6"
 
 redux-thunk@2.3.0:
   version "2.3.0"


### PR DESCRIPTION
This PR removes fairly redundant dependency and opts for manually calling thunk methods, resulting in less code overall. Like the `moxios` package, the `redux-mock-store` package was another layer of abstraction that in hindsight offered quite little.

- Removing `redux-mock-store` package.
- Manually calling thunk method and passing in a jest mock.
- No longer exporting middleware from our store.