### PR TITLE
Adding build args during Heroku container build/push

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -46,7 +46,7 @@ jobs:
         run: heroku container:login
 
       - name: Build and push image to Heroku registry
-        run: heroku container:push web --app=$HEROKU_APP_NAME
+        run: heroku container:push web --app=$HEROKU_APP_NAME --arg GOOGLE_SITE_VERIFICATION_TOKEN=$GOOGLE_SITE_VERIFICATION_TOKEN
 
       - name: Release image to Heroku application
         run: heroku container:release web --app=$HEROKU_APP_NAME


### PR DESCRIPTION
The `GOOGLE_SITE_VERIFICATION_TOKEN` environment variable / build argument wasn't showing up in the final output. This is because it wasn't getting passed into the `heroku container:push` command.