### PR TITLE
Removing immutable exceptions from linting rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,7 @@
     "camelcase": "error",
     "dot-notation": "error",
     "eqeqeq": ["error", "allow-null"],
-    "new-cap": ["error", {"capIsNewExceptions": ["Immutable.List", "Immutable.Map", "Immutable.Set", "Immutable.OrderedMap"]}],
+    "new-cap": "error",
     "no-caller": "error",
     "no-console": "error",
     "no-multi-str": "error",


### PR DESCRIPTION
With the recent merging of #100 there is no further need to have linting exceptions for Immutable constructs, as Immutable is no longer part of the application.