### PR TITLE
Adding launch.json for remote debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug in Chrome",
+      "type": "chrome",
+      "request":"launch",
+      "url": "http://localhost:8080",
+      "webRoot": "${workspaceFolder}",
+      "sourceMaps": true
+    }
+  ]
+}


### PR DESCRIPTION
Adds `.vscode/launch.json` which is configured to start a separate instance of chrome already configured to allow debugging via a port that VSCode knows about internally.

The `webRoot` folder is an absolute path to our project directory, used to resolve paths such as `src/components/avatar/index.js` that VSCode's debugger may receive from a call stack or source map.

Usage Guide:
- Start the application outside of VSCode (either production or development mode). Development mode is preferred as hot module reloading via `react-refresh` works nicely without having to restart the debugger.
- Once the application is started and serving traffic from http://localhost:8080 then start the debugger in VSCode. This will open a new chrome window already configured to allow remote debugging via an internal port.
- Apply breakpoints via VSCode, trigger them via the browser window and VSCode should update to show you variables, closures etc and allow you to step / continue execution.