### PR TITLE
Adding dotenv package for local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "compression": "1.7.4",
     "core-js": "3.6.5",
     "cors": "2.8.5",
+    "dotenv": "8.2.0",
     "express": "4.17.1",
     "express-winston": "4.0.5",
     "lodash": "4.17.19",

--- a/server/index.mjs
+++ b/server/index.mjs
@@ -1,3 +1,4 @@
+import 'dotenv/config.js';
 import path from 'path';
 import express from 'express';
 import expressWinston from 'express-winston';

--- a/webpack/env.development.js
+++ b/webpack/env.development.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const webpackMerge = require('webpack-merge');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4609,6 +4609,11 @@ dot-prop@^4.1.1:
   dependencies:
     is-obj "^1.0.0"
 
+dotenv@8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 download@^6.2.2:
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/download/-/download-6.2.5.tgz#acd6a542e4cd0bb42ca70cfc98c9e43b07039714"


### PR DESCRIPTION
Adds the `dotenv` package so that local development (sans docker) will no longer need environment variables supplied in the CLI. Instead, the contents of a `.env` file can be read at runtime. There are two locations that utilize `dotenv`; the entrypoint for the node service (`server/index.mjs`) and the webpack development server (`webpack/env.development.js`).