### PR TITLE
refactor: removing @babel/plugin-proposal-class-properties

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -19,7 +19,6 @@
     ]
   ],
   "plugins": [
-    "@babel/plugin-proposal-class-properties",
     "@babel/plugin-transform-runtime"
   ],
   "env": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "devDependencies": {
     "@babel/core": "7.11.6",
-    "@babel/plugin-proposal-class-properties": "7.10.4",
     "@babel/plugin-transform-runtime": "7.11.5",
     "@babel/preset-env": "7.11.5",
     "@babel/preset-react": "7.10.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -560,7 +560,7 @@
     "@babel/helper-remap-async-to-generator" "^7.10.4"
     "@babel/plugin-syntax-async-generators" "^7.8.0"
 
-"@babel/plugin-proposal-class-properties@7.10.4", "@babel/plugin-proposal-class-properties@^7.10.4":
+"@babel/plugin-proposal-class-properties@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz#a33bf632da390a59c7a8c570045d1115cd778807"
   integrity sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==


### PR DESCRIPTION
This PR removes the `@babel/plugin-proposal-class-properties` package for two reasons:
1. The package is included by default within `@babel/preset-env`.
2. Class components with static `propTypes` are no longer used in the application.