### PR TITLE
feat: adding lazy loading to imagery

### DIFF
--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -43,8 +43,11 @@ const App = ({ onComponentDidMount, showError, showLoader }) => {
           <img
             alt="Dishonored 2 logo"
             className={`${namespace}__logo-graphic`}
+            draggable="false"
             sizes="100vw"
             srcSet={`${logo660} 660w, ${logo1320} 1320w`}
+            width="660"
+            height="90"
           />
         </Link>
       </header>

--- a/src/components/app/tests/__snapshots__/index.spec.js.snap
+++ b/src/components/app/tests/__snapshots__/index.spec.js.snap
@@ -19,8 +19,11 @@ exports[`App component when rendered renders a header area and top-level routes 
       <img
         alt="Dishonored 2 logo"
         className="app__logo-graphic"
+        draggable="false"
+        height="90"
         sizes="100vw"
         srcSet="660x90.png 660w, 1320x180.png 1320w"
+        width="660"
       />
     </MockLink>
   </header>

--- a/src/components/avatar/index.js
+++ b/src/components/avatar/index.js
@@ -15,6 +15,9 @@ const Avatar = ({ className, name, slug }) => (
     draggable="false"
     src={characterSlugToPortrait.get(slug)}
     alt={`Portrait of ${name}`}
+    width="771"
+    height="901"
+    loading="lazy"
   />
 );
 

--- a/src/components/avatar/stylesheets/index.scss
+++ b/src/components/avatar/stylesheets/index.scss
@@ -1,5 +1,5 @@
 .avatar {
-  aspect-ratio: 771 / 901;
   display: block;
+  height: auto;
   width: 100%;
 }

--- a/src/components/avatar/tests/__snapshots__/index.spec.js.snap
+++ b/src/components/avatar/tests/__snapshots__/index.spec.js.snap
@@ -5,13 +5,16 @@ Snapshot Diff:
 - First value
 + Second value
 
+@@ -1,8 +1,8 @@
   <img
     alt="Portrait of Fake Name"
 -   className="avatar"
 +   className="avatar mock-class"
     draggable="false"
+    height="901"
+    loading="lazy"
     src="mock-src"
-  />
+    width="771"
 `;
 
 exports[`Avatar component when rendered renders a wrapping element containing an image 1`] = `
@@ -19,6 +22,9 @@ exports[`Avatar component when rendered renders a wrapping element containing an
   alt="Portrait of Fake Name"
   className="avatar"
   draggable="false"
+  height="901"
+  loading="lazy"
   src="mock-src"
+  width="771"
 />
 `;


### PR DESCRIPTION
Adding `loading="lazy"` onto imagery so that the browser will defer the loading of said images until they appear within a certain threshold away from the visible viewport. At the time of writing, that appeared to be about 2000px on a desktop.

The PR adds `width` and `height` attributes into image elements again to aid the browser in calculating the aspect ratio of the image. These attributes are overridden by CSS equivalents to ensure the image is responsive, with the aspect ratio immediately calculable even before the image loads. The presence of the `width` and `height` attributes also aid in stopping"layout shifting" where images don't take up the right amount of space on the page until the browser loads them, determines the correct width / height / aspect ratio, and then lays out the screen again. `height: auto;` has also been added to avatar images to override the hardcoded height attribute on the image elements. This ensures the height will stay proportionate to the responsive width.

Other Changes:
- Ensuring the logo is not draggable.
- Removing `aspect-ratio` from image elements, as it will be preset by the browsers user-agent styles based on the supplied `width` and `height` attributes.

More Information:
- [Browser-level image lazy-loading for the web](https://web.dev/browser-level-image-lazy-loading/)
- [Do This to Improve Image Loading on Your Website](https://www.youtube.com/watch?v=4-d_SoCHeWE)
- [Setting Height And Width On Images Is Important Again](https://www.smashingmagazine.com/2020/03/setting-height-width-images-important-again/)