### PR TITLE
feat: adding example of prefers-reduced-motion media query

### DIFF
--- a/src/components/character-selection/stylesheets/index.scss
+++ b/src/components/character-selection/stylesheets/index.scss
@@ -70,6 +70,14 @@ $characterNamespace: 'character';
       transition: flex 300ms ease-in;
       will-change: flex;
     }
+
+    @media (prefers-reduced-motion) {
+      transition: none;
+
+      &::before {
+        transition: none;
+      }
+    }
   }
 
   &__name {


### PR DESCRIPTION
This PR adds the user preference media query `prefers-reduced-motion` which helps tailor the web experience for users who don't want lots of animation. It is used here to cancel transitions on the character selection screen. The character overlay will appear instantly rather than slide into place.

![prefers-reduced-motion](https://user-images.githubusercontent.com/167421/119410018-11aa4600-bce0-11eb-9c10-18c5db4a2e40.gif)