### PR TITLE
fix: removing old images folder entry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@
 # White list only the required files and folders.
 !__mocks__/
 !html/
-!images/
 !manifests/
 !server/
 !src/


### PR DESCRIPTION
Removing an entry around a top-level images directory that was forgotten to be removed in #117.