### PR TITLE
fix: removing old image volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ services:
       - ${PORT}:${PORT}
     volumes:
       - ./html:/dishonored/html
-      - ./images:/dishonored/images
       - ./manifests:/dishonored/manifests
       - ./server:/dishonored/server
       - ./src:/dishonored/src


### PR DESCRIPTION
Removing an entry around mounting a volume on the top-level images directory that was forgotten to be removed in #117.