### PR TITLE
feat: adding separate workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
-name: release
+name: Release
 
 on:
   workflow_run:
-    workflows: ["test"]
+    workflows: ["Test"]
     types: [completed]
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: release
+
+on:
+  workflow_run:
+    workflows: ["test"]
+    types: [completed]
+
+env:
+  GOOGLE_SITE_VERIFICATION_TOKEN: cj8IJgpHPbgqe4Xs9_dAAUzO07qGnnnz5SlSN32fOnA
+  PORT: 8080
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/master' && github.event.workflow_run.conclusion == 'success' }}
+    env:
+      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      HEROKU_APP_NAME: dishonored2-power-calculator
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Login to Heroku
+        run: heroku container:login
+
+      - name: Build and push image to Heroku registry
+        run: heroku container:push web --app=$HEROKU_APP_NAME --arg GOOGLE_SITE_VERIFICATION_TOKEN=$GOOGLE_SITE_VERIFICATION_TOKEN
+
+      - name: Release image to Heroku application
+        run: heroku container:release web --app=$HEROKU_APP_NAME

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test
+name: Test
 
 on:
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
-name: test-and-release
+name: test
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 env:
   GOOGLE_SITE_VERIFICATION_TOKEN: cj8IJgpHPbgqe4Xs9_dAAUzO07qGnnnz5SlSN32fOnA
@@ -33,23 +37,3 @@ jobs:
           flags: unittests
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: false
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [test]
-    if: github.ref == 'refs/heads/master'
-    env:
-      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-      HEROKU_APP_NAME: dishonored2-power-calculator
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Login to Heroku
-        run: heroku container:login
-
-      - name: Build and push image to Heroku registry
-        run: heroku container:push web --app=$HEROKU_APP_NAME --arg GOOGLE_SITE_VERIFICATION_TOKEN=$GOOGLE_SITE_VERIFICATION_TOKEN
-
-      - name: Release image to Heroku application
-        run: heroku container:release web --app=$HEROKU_APP_NAME


### PR DESCRIPTION
This PR separates the test and release jobs into separate workflows, allowing us to showcase the `workflow_runs` event to make sequential workflows.

Rather than running the `test` workflow on every single push, it now only runs when a Pull Request is opened / updated with new commits, or when that pull request is merged to `master`.

The `release` workflow now only triggers as a result of the `test` workflow running successfully against the `master` branch. This change means if a PR was merged into `master` and ultimately fails it's checks (perhaps the branch and it's tests going green was stale and wasn't rebased to highlight any new failures) then at least it won't be released.