### PR TITLE
fix: removing dry-run flag from semantic-release command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Trigger semantic release
-        run: npx semantic-release --dry-run
+        run: npx semantic-release
 
       - name: Login to Heroku
         run: heroku container:login


### PR DESCRIPTION
Removing the `dry-run` feature flag and in the background, have ensured that the `GH_TOKEN` environment variable has been set with a very limited scope personal access token.