### PR TITLE
Updating release workflow to allow dispatching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
       HEROKU_APP_NAME: dishonored2-power-calculator
     steps:
-      run : "echo $CONTENT"
     - name : machine echo github
       env : { CONTENT : "${{ toJson(github) }}" }
       run : "echo $CONTENT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,33 +10,28 @@ on:
       - completed
 
 env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
   GOOGLE_SITE_VERIFICATION_TOKEN: cj8IJgpHPbgqe4Xs9_dAAUzO07qGnnnz5SlSN32fOnA
+  HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+  HEROKU_APP_NAME: dishonored2-power-calculator
   PORT: 8080
 
 jobs:
   release:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    env:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-      HEROKU_APP_NAME: dishonored2-power-calculator
     steps:
-    - name : machine echo github
-      env : { CONTENT : "${{ toJson(github) }}" }
-      run : "echo $CONTENT"
-    - name : machine echo runner
-      env : { CONTENT : "${{ toJson(runner) }}" }
-      run : "echo $CONTENT"
-    - name : machine echo job
-      env : { CONTENT : "${{ toJson(job) }}" }
-      run : "echo $CONTENT"
-    - name : machine echo strategy
-      env : { CONTENT : "${{ toJson(strategy) }}" }
-      run : "echo $CONTENT"
-    - name : machine echo matrix
-      env : { CONTENT : "${{ toJson(matrix) }}" }
-      run : "echo $CONTENT"
-    - name : machine echo steps
-      env : { CONTENT : "${{ toJson(steps) }}" }
-      run : "echo $CONTENT"
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Trigger semantic release
+        run: npx semantic-release
+
+      - name: Login to Heroku
+        run: heroku container:login
+
+      - name: Build and push image to Heroku registry
+        run: heroku container:push web --app=$HEROKU_APP_NAME --arg GOOGLE_SITE_VERIFICATION_TOKEN=$GOOGLE_SITE_VERIFICATION_TOKEN
+
+      - name: Release image to Heroku application
+        run: heroku container:release web --app=$HEROKU_APP_NAME

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,17 +22,21 @@ jobs:
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
       HEROKU_APP_NAME: dishonored2-power-calculator
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Trigger semantic release
-        run: npx semantic-release
-
-      - name: Login to Heroku
-        run: heroku container:login
-
-      - name: Build and push image to Heroku registry
-        run: heroku container:push web --app=$HEROKU_APP_NAME --arg GOOGLE_SITE_VERIFICATION_TOKEN=$GOOGLE_SITE_VERIFICATION_TOKEN
-
-      - name: Release image to Heroku application
-        run: heroku container:release web --app=$HEROKU_APP_NAME
+      run : "echo $CONTENT"
+    - name : machine echo github
+      env : { CONTENT : "${{ toJson(github) }}" }
+      run : "echo $CONTENT"
+    - name : machine echo runner
+      env : { CONTENT : "${{ toJson(runner) }}" }
+      run : "echo $CONTENT"
+    - name : machine echo job
+      env : { CONTENT : "${{ toJson(job) }}" }
+      run : "echo $CONTENT"
+    - name : machine echo strategy
+      env : { CONTENT : "${{ toJson(strategy) }}" }
+      run : "echo $CONTENT"
+    - name : machine echo matrix
+      env : { CONTENT : "${{ toJson(matrix) }}" }
+      run : "echo $CONTENT"
+    - name : machine echo steps
+      env : { CONTENT : "${{ toJson(steps) }}" }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,3 +39,4 @@ jobs:
       run : "echo $CONTENT"
     - name : machine echo steps
       env : { CONTENT : "${{ toJson(steps) }}" }
+      run : "echo $CONTENT"


### PR DESCRIPTION
This PR updates the conditional to check if the event name is set to `workflow_dispatch`. If so, pass the conditional so that the release can occur. This ensures we can manually dispatch the workflow, and still restrict it to automatic runs only against `master`.