### PR TITLE
Typescript 4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "stylelint-scss": "3.19.0",
     "ts-jest": "27.0.2",
     "ts-node-dev": "1.1.6",
-    "typescript": "4.3.2",
+    "typescript": "4.4.3",
     "webpack": "5.37.0",
     "webpack-bundle-analyzer": "4.4.2",
     "webpack-cli": "4.7.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "allowSyntheticDefaultImports": true,
     "baseUrl": "src",
     "esModuleInterop": true,
+    "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13126,10 +13126,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
-  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+typescript@4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
+  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
 
 uglify-js@^3.1.4:
   version "3.14.1"


### PR DESCRIPTION
What's new?
https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/

This PR upgrades to TypeScript 4.4 and enables the [exactOptionalPropertyTypes](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) option within `tsconfig.json`.