### PR TITLE
feat: upgrading node to utilize new node import prefixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17.0-slim AS base
+FROM node:14.18.0-slim AS base
 
 LABEL maintainer="Anthony Hastings <ar.hastings@gmail.com>"
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/jest": "26.0.23",
     "@types/lodash": "4.14.170",
     "@types/mini-css-extract-plugin": "^1.4.3",
-    "@types/node": "15.12.1",
+    "@types/node": "14.18.5",
     "@types/react": "17.0.6",
     "@types/react-dom": "17.0.5",
     "@types/react-redux": "7.1.16",

--- a/server/index.mts
+++ b/server/index.mts
@@ -1,6 +1,6 @@
 import 'dotenv/config.js';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import express from 'express';
 import expressWinston from 'express-winston';
 import compression from 'compression';

--- a/support/paths.ts
+++ b/support/paths.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 const projectRoot = process.cwd();
 

--- a/support/tests/file-transformer.js
+++ b/support/tests/file-transformer.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 
 module.exports = {
   process(src, filename) {

--- a/webpack/base.ts
+++ b/webpack/base.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import type { Configuration } from 'webpack';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';

--- a/webpack/env.development.ts
+++ b/webpack/env.development.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config.js';
-import path from 'path';
+import path from 'node:path';
 import type { Configuration } from 'webpack';
 import { merge as webpackMerge } from 'webpack-merge';
 import CopyWebpackPlugin from 'copy-webpack-plugin';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,10 +2148,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.0.3.tgz#ee09fcaac513576474c327da5818d421b98db88a"
   integrity sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ==
 
-"@types/node@15.12.1":
-  version "15.12.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.1.tgz#9b60797dee1895383a725f828a869c86c6caa5c2"
-  integrity sha512-zyxJM8I1c9q5sRMtVF+zdd13Jt6RU4r4qfhTd7lQubyThvLfx6yYekWSQjGCGV2Tkecgxnlpl/DNlb6Hg+dmEw==
+"@types/node@14.18.5":
+  version "14.18.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.5.tgz#0dd636fe7b2c6055cbed0d4ca3b7fb540f130a96"
+  integrity sha512-LMy+vDDcQR48EZdEx5wRX1q/sEl6NdGuHXPnfeL8ixkwCOSZ2qnIyIZmcCbdX0MeRqHhAcHmX+haCbrS8Run+A==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
- Upgrading NodeJS to `14.18.0` which is the earliest version in the v14 version where the node imports feature was backported to.
- Keeping `@types/node` major and minor version in line with the version of NodeJS (as this is how they match - the patch version is for fixes).
- Adding `node:` prefix to built-in imports to better distinguish between built-in packages, and node modules.

More Information:
https://nodejs.org/docs/latest-v14.x/api/esm.html#esm_node_imports