### PR TITLE
chore: upgrading dotenv package

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "classnames": "2.3.1",
     "compression": "1.7.4",
     "core-js": "3.6.5",
-    "dotenv": "8.2.0",
+    "dotenv": "10.0.0",
     "express": "4.17.1",
     "express-winston": "4.0.5",
     "lodash": "4.17.21",

--- a/server/index.mts
+++ b/server/index.mts
@@ -1,4 +1,4 @@
-import 'dotenv/config.js';
+import 'dotenv/config';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import express from 'express';

--- a/webpack/env.development.ts
+++ b/webpack/env.development.ts
@@ -1,4 +1,4 @@
-import 'dotenv/config.js';
+import 'dotenv/config';
 import path from 'node:path';
 import type { Configuration } from 'webpack';
 import { merge as webpackMerge } from 'webpack-merge';

--- a/webpack/env.production.ts
+++ b/webpack/env.production.ts
@@ -1,4 +1,4 @@
-import 'dotenv/config.js';
+import 'dotenv/config';
 import type { Configuration } from 'webpack';
 import { merge as webpackMerge } from 'webpack-merge';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4937,10 +4937,10 @@ dot-prop@^5.1.0, dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-dotenv@8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
-  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+dotenv@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
+  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
 download@^6.2.2:
   version "6.2.5"


### PR DESCRIPTION
Upgrades `dotenv` to the latest major version which fixes a previous import issue where we needed to import a package with a superfluous file extension.