### PR TITLE
feat: specifying terser plugin options

### DIFF
--- a/webpack/env.production.ts
+++ b/webpack/env.production.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import type { Configuration } from 'webpack';
 import { merge as webpackMerge } from 'webpack-merge';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+import TerserPlugin from 'terser-webpack-plugin';
 import ImageMinimizerPlugin from 'image-minimizer-webpack-plugin';
 import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 import baseConfig from './base';
@@ -20,7 +21,14 @@ export default (env: EnvOptions = {}): Configuration => {
     },
     optimization: {
       minimizer: [
-        '...',
+        new TerserPlugin({
+          extractComments: false,
+          terserOptions: {
+            compress: {
+              passes: 2,
+            },
+          },
+        }),
         new ImageMinimizerPlugin({
           minimizer: {
             implementation: ImageMinimizerPlugin.imageminMinify,


### PR DESCRIPTION
Adding the `TerserPlugin` rather than using the default one, so that we can include the `extractComments` option. This will ensure we don't get a `LICENSE.txt` file output in the `dist/` directory. The license still exists in the main bundle, they've just not been extracted into an individual bundle.

These are the settings that webpack applies by default under the hood:
https://github.com/webpack/webpack/blob/f43047c4c2aa4b0a315328e4c34a319dc2662254/lib/config/defaults.js#L1157-L1163

Note: I've not added `terser-webpack-plugin` into the `package.json` dev dependencies because it's already a dependency of the `webpack` module, and I think that's fine.

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/167421/161350204-88e4b5ce-c831-4e03-9a49-05677b84195f.png) | ![after](https://user-images.githubusercontent.com/167421/161350212-826a2ba3-075a-440c-a0d3-299c3012ec8b.png) |
