### PR TITLE
feat: adding support for non-hover devices

### DIFF
--- a/src/components/character-selection/stylesheets/character-selection.scss
+++ b/src/components/character-selection/stylesheets/character-selection.scss
@@ -34,16 +34,6 @@ $character-namespace: 'character';
   overflow: hidden;
   position: relative;
 
-  &:hover {
-    .#{$character-namespace}__overlay {
-      transform: translateY(0);
-
-      &::before {
-        flex-grow: 1;
-      }
-    }
-  }
-
   &__overlay {
     background-color: rgb(0 0 0 / 88%);
     display: flex;
@@ -56,8 +46,6 @@ $character-namespace: 'character';
     overflow: hidden;
     padding: 2rem;
     position: absolute;
-    transform: translateY(calc(100% - 6rem));
-    transition: transform 300ms ease-in;
 
     &::before,
     &::after {
@@ -65,18 +53,35 @@ $character-namespace: 'character';
       display: block;
       flex: 1 1 auto;
     }
+  }
 
-    &::before {
-      flex-grow: 0;
-      transition: flex 300ms ease-in;
-      will-change: flex;
-    }
-
-    @media (prefers-reduced-motion) {
-      transition: none;
+  @media (hover: hover) {
+    &__overlay {
+      transform: translateY(calc(100% - 6rem));
+      transition: transform 300ms ease-in;
 
       &::before {
+        flex-grow: 0;
+        transition: flex 300ms ease-in;
+        will-change: flex;
+      }
+
+      @media (prefers-reduced-motion) {
         transition: none;
+
+        &::before {
+          transition: none;
+        }
+      }
+    }
+
+    &:hover {
+      .#{$character-namespace}__overlay {
+        transform: translateY(0);
+
+        &::before {
+          flex-grow: 1;
+        }
       }
     }
   }


### PR DESCRIPTION
Non-hover devices will have the overlay fully revealed at all times.

Hover devices will have the overlay partially revealed:
  - Users preferring reduced motion will have the overlay reveal fully and instantly upon hover.
  - Users with no preference on motion will have the overlay reveal fully in an animated way.

| Hover with / without Reduced Motion | Hover / No Hover (Touch Device) |
| --- | --- |
| ![hover](https://user-images.githubusercontent.com/167421/173255393-3e8ff283-3814-4d91-93fa-4f3f3a176019.gif) | ![touch_simulation](https://user-images.githubusercontent.com/167421/173255369-a0781c67-579d-4fd4-b6e0-6b0c56c9a29e.gif) |