### PR TITLE
refactor: updating react component typings

### DIFF
--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -25,7 +25,7 @@ const PowerSelectionRouteValidation = lazy(
 
 const namespace = 'app';
 
-export const App: React.FC = (): JSX.Element => {
+export const App = () => {
   const showError = useAppSelector(hasInitialDataFailedSelector);
   const showLoader = useAppSelector(isInitialDataIncompleteSelector);
   const dispatch = useAppDispatch();

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -11,11 +11,7 @@ export interface AvatarProps {
 
 const namespace = 'avatar';
 
-export const Avatar: React.FC<AvatarProps> = ({
-  className = '',
-  name,
-  slug,
-}): JSX.Element => (
+export const Avatar = ({ className = '', name, slug }: AvatarProps) => (
   <img
     className={classNames({
       [namespace]: true,

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -10,11 +10,7 @@ export interface ButtonProps {
 
 const namespace = 'button';
 
-export const Button: React.FC<ButtonProps> = ({
-  children,
-  className = '',
-  href,
-}): JSX.Element => {
+export const Button = ({ children, className = '', href }: ButtonProps) => {
   const classes = classNames({
     [namespace]: true,
     [className]: Boolean(className),

--- a/src/components/character-selection/character-selection.tsx
+++ b/src/components/character-selection/character-selection.tsx
@@ -6,7 +6,7 @@ import './stylesheets/character-selection.scss';
 
 const characterNamespace = 'character';
 
-export const CharacterSelection: React.FC = (): JSX.Element => {
+export const CharacterSelection = () => {
   const characters = useAppSelector(charactersDataSelector);
 
   return (

--- a/src/components/loader/loader.tsx
+++ b/src/components/loader/loader.tsx
@@ -10,11 +10,11 @@ export interface LoaderProps {
 
 const namespace = 'app-loader';
 
-export const Loader: React.FC<LoaderProps> = ({
+export const Loader = ({
   children = <React.Fragment></React.Fragment>,
   showError = false,
   showLoader = false,
-}): JSX.Element => {
+}: LoaderProps) => {
   if (!showError && !showLoader) return children;
 
   return (

--- a/src/components/outsiders-mark/outsiders-mark.tsx
+++ b/src/components/outsiders-mark/outsiders-mark.tsx
@@ -8,10 +8,10 @@ export interface OutsidersMarkProps {
 
 const namespace = 'outsiders-mark';
 
-export const OutsidersMark: React.FC<OutsidersMarkProps> = ({
+export const OutsidersMark = ({
   animated = false,
   className = '',
-}): JSX.Element => {
+}: OutsidersMarkProps) => {
   const classes = classNames({
     [namespace]: true,
     [`${namespace}--is-animating`]: animated,

--- a/src/components/page-not-found/page-not-found.tsx
+++ b/src/components/page-not-found/page-not-found.tsx
@@ -3,7 +3,7 @@ import { OutsidersMark } from '@/components/outsiders-mark';
 
 const namespace = 'page-not-found';
 
-export const PageNotFound = (): JSX.Element => (
+export const PageNotFound = () => (
   <div className={namespace}>
     <h1 className={`${namespace}__message`}>Page Not Found</h1>
     <OutsidersMark animated={false} className={`${namespace}__icon`} />

--- a/src/components/power-selection/power-selection.tsx
+++ b/src/components/power-selection/power-selection.tsx
@@ -17,7 +17,7 @@ const PageNotFound = lazy(() => import('@/components/page-not-found'));
 
 const namespace = 'power-selection';
 
-export const PowerSelection: React.FC = (): JSX.Element => {
+export const PowerSelection = () => {
   const { characterSlug } = useParams() as { characterSlug: CharacterSlugs };
   const topLevelEnhancements = useAppSelector(topLevelEnhancementsSelector);
   const topLevelPowers = useAppSelector((state: RootState) =>

--- a/src/components/power-selection/powers-list.tsx
+++ b/src/components/power-selection/powers-list.tsx
@@ -10,11 +10,11 @@ export interface PowersListProps {
 
 const namespace = 'powers-list';
 
-export const PowersList: React.FC<PowersListProps> = ({
+export const PowersList = ({
   children,
   className = '',
   powers,
-}): JSX.Element => {
+}: PowersListProps) => {
   const classes = classNames({
     [namespace]: true,
     [className]: Boolean(className),


### PR DESCRIPTION
Removing instances of `React.FC` which in the React community has now become discouraged.

More Information:
- https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/function_components
- https://backstage.io/docs/architecture-decisions/adrs-adr006