### PR TITLE
refactor: renaming master to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   workflow_run:
     workflows: ["Test"]
     branches:
-      - master
+      - main
     types:
       - completed
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 env:
   GOOGLE_SITE_VERIFICATION_TOKEN: cj8IJgpHPbgqe4Xs9_dAAUzO07qGnnnz5SlSN32fOnA

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": "master",
+  "branches": "main",
   "plugins": [
     ["@semantic-release/commit-analyzer", {
       "preset": "angular"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://github.com/anthonyhastings/dishonored2-power-calculator/actions/workflows/release.yml/badge.svg?branch=master "Build Status")](https://github.com/anthonyhastings/dishonored2-power-calculator/actions?query=workflow%3Arelease+branch%3Amaster)
-[![Coverage Status](https://codecov.io/gh/anthonyhastings/dishonored2-power-calculator/branch/master/graph/badge.svg "Coverage Status")](https://codecov.io/gh/anthonyhastings/dishonored2-power-calculator)
+[![Build Status](https://github.com/anthonyhastings/dishonored2-power-calculator/actions/workflows/release.yml/badge.svg?branch=main "Build Status")](https://github.com/anthonyhastings/dishonored2-power-calculator/actions?query=workflow%3Arelease+branch%3Amain)
+[![Coverage Status](https://codecov.io/gh/anthonyhastings/dishonored2-power-calculator/branch/main/graph/badge.svg "Coverage Status")](https://codecov.io/gh/anthonyhastings/dishonored2-power-calculator)
 
 ## Instructions
 


### PR DESCRIPTION
For a number of years there has been a push within the community to move trunk branches from `master` to `main` as it's a more inclusive term. The branch has already been updated at this point, and the configuration files within the repository are being updated to match.