### PR TITLE
feat: moving from heroku to vercel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,3 @@ jobs:
 
       - name: Trigger semantic release
         run: npx semantic-release
-
-      - name: Login to Heroku
-        run: heroku container:login
-
-      - name: Build and push image to Heroku registry
-        run: heroku container:push web --app=$HEROKU_APP_NAME --arg GOOGLE_SITE_VERIFICATION_TOKEN=$GOOGLE_SITE_VERIFICATION_TOKEN
-
-      - name: Release image to Heroku application
-        run: heroku container:release web --app=$HEROKU_APP_NAME

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
       name="description"
       content="Determine the perfect build for your Dishonored 2 character before spending runes."
     />
-    <title>Dishonored 2: Power Calculator</title>
+    <title>Dishonored 2 - Power Calculator</title>
     <link
       rel="icon"
       type="image/png"


### PR DESCRIPTION
Heroku no longer has a free / hobby tier so this PR removes it from the release workflow.

At the same time, I've set up a project within Vercel which relies on a git integration. There's no configuration within this repository or it's source code.